### PR TITLE
Import all checks from one package

### DIFF
--- a/checks/all/all.go
+++ b/checks/all/all.go
@@ -1,0 +1,7 @@
+// Package all imports all other check-containing packages, for the side-effect
+// of having them registered in the check registry.
+package all
+
+import (
+	_ "github.com/digitalocean/clusterlint/checks/noop"
+)

--- a/cmd/clusterlint/main.go
+++ b/cmd/clusterlint/main.go
@@ -8,10 +8,12 @@ import (
 	"sync"
 
 	"github.com/digitalocean/clusterlint/checks"
-	_ "github.com/digitalocean/clusterlint/checks/noop"
 	"github.com/digitalocean/clusterlint/kube"
 	"github.com/urfave/cli"
 	"golang.org/x/sync/errgroup"
+
+	// Side-effect import to get all the checks registered.
+	_ "github.com/digitalocean/clusterlint/checks/all"
 )
 
 const all string = ""


### PR DESCRIPTION
Introduce a "meta" check package, `checks/all`, that will import all the other packages that contain checks. Then main or other packages that want to use checks need only import `checks/all` and will get all the checks registered.

This doesn't feel like a perfect solution, but I think it's tidy enough to go with for the moment at least.