### PR TITLE
Remove quotas and limits from default-namespace check.

### DIFF
--- a/checks/basic/namespace.go
+++ b/checks/basic/namespace.go
@@ -97,24 +97,6 @@ func checkConfigMaps(items *corev1.ConfigMapList, alert *alert) {
 	}
 }
 
-// checkQuotas checks if there are quotas in the default namespace
-func checkQuotas(items *corev1.ResourceQuotaList, alert *alert) {
-	for _, item := range items.Items {
-		if corev1.NamespaceDefault == item.GetNamespace() {
-			alert.warn("Resource Quota", item.ObjectMeta)
-		}
-	}
-}
-
-// checkLimits checks if there are limits in the default namespace
-func checkLimits(items *corev1.LimitRangeList, alert *alert) {
-	for _, item := range items.Items {
-		if corev1.NamespaceDefault == item.GetNamespace() {
-			alert.warn("Limit Range", item.ObjectMeta)
-		}
-	}
-}
-
 // checkServices checks if there are user created services in the default namespace
 func checkServices(items *corev1.ServiceList, alert *alert) {
 	for _, item := range items.Items {
@@ -165,16 +147,6 @@ func (nc *defaultNamespaceCheck) Run(objects *kube.Objects) (warnings []error, e
 
 	g.Go(func() error {
 		checkConfigMaps(objects.ConfigMaps, alert)
-		return nil
-	})
-
-	g.Go(func() error {
-		checkQuotas(objects.ResourceQuotas, alert)
-		return nil
-	})
-
-	g.Go(func() error {
-		checkLimits(objects.LimitRanges, alert)
 		return nil
 	})
 

--- a/checks/basic/namespace_test.go
+++ b/checks/basic/namespace_test.go
@@ -68,8 +68,9 @@ func userCreatedObjects() *kube.Objects {
 	objs.PodTemplates = &corev1.PodTemplateList{Items: []corev1.PodTemplate{{ObjectMeta: metav1.ObjectMeta{Name: "template_foo", Namespace: "default"}}}}
 	objs.PersistentVolumeClaims = &corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "pvc_foo", Namespace: "default"}}}}
 	objs.ConfigMaps = &corev1.ConfigMapList{Items: []corev1.ConfigMap{{ObjectMeta: metav1.ObjectMeta{Name: "cm_foo", Namespace: "default"}}}}
-	objs.ResourceQuotas = &corev1.ResourceQuotaList{Items: []corev1.ResourceQuota{{ObjectMeta: metav1.ObjectMeta{Name: "quota_foo", Namespace: "default"}}}}
-	objs.LimitRanges = &corev1.LimitRangeList{Items: []corev1.LimitRange{{ObjectMeta: metav1.ObjectMeta{Name: "limit_foo", Namespace: "default"}}}}
+	objs.Services = &corev1.ServiceList{Items: []corev1.Service{{ObjectMeta: metav1.ObjectMeta{Name: "svc_foo", Namespace: "default"}}}}
+	objs.Secrets = &corev1.SecretList{Items: []corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "secret_foo", Namespace: "default"}}}}
+	objs.ServiceAccounts = &corev1.ServiceAccountList{Items: []corev1.ServiceAccount{{ObjectMeta: metav1.ObjectMeta{Name: "sa_foo", Namespace: "default"}}}}
 	return objs
 }
 
@@ -79,8 +80,9 @@ func errors() []error {
 		fmt.Errorf("Pod template 'template_foo' is in the default namespace."),
 		fmt.Errorf("Persistent Volume Claim 'pvc_foo' is in the default namespace."),
 		fmt.Errorf("Config Map 'cm_foo' is in the default namespace."),
-		fmt.Errorf("Resource Quota 'quota_foo' is in the default namespace."),
-		fmt.Errorf("Limit Range 'limit_foo' is in the default namespace."),
+		fmt.Errorf("Service 'svc_foo' is in the default namespace."),
+		fmt.Errorf("Secret 'secret_foo' is in the default namespace."),
+		fmt.Errorf("Service Account 'sa_foo' is in the default namespace."),
 	}
 	return w
 }


### PR DESCRIPTION
* It is perfectly reasonable to have resource quotas and limit ranges in the default namespace in order to avoid resource monopolization.