### PR TITLE
Check if resource requests and limits are set on pods

### DIFF
--- a/checks.md
+++ b/checks.md
@@ -383,3 +383,46 @@ How to fix:
 ```bash
 kubectl delete secret <unused secret name>
 ```
+
+###### Resource Requests and Limits
+
+Name: `resource-requirements`
+
+Group: `basic`
+
+Description: When Containers have resource requests specified, the scheduler can make better decisions about which nodes to place Pods on. And when Containers have their limits specified, contention for resources on a node can be handled in a specified manner.
+
+Example:
+
+```yaml
+# Don't do this
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  containers:
+  - image: docker.io/nginx:1.17.0
+    name: test-container
+
+```
+
+How to fix:
+
+```yaml
+# Specify resource requests and limits
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pd
+spec:
+  containers:
+  - image: docker.io/nginx:1.17.0
+    name: test-container
+    resources:
+      limits:
+        cpu: 102m
+      requests:
+        cpu: 102m
+
+```

--- a/checks/basic/resource_requests.go
+++ b/checks/basic/resource_requests.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"fmt"
+
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func init() {
+	checks.Register(&resourceRequirementsCheck{})
+}
+
+type resourceRequirementsCheck struct{}
+
+// Name returns a unique name for this check.
+func (r *resourceRequirementsCheck) Name() string {
+	return "resource-requirements"
+}
+
+// Groups returns a list of group names this check should be part of.
+func (r *resourceRequirementsCheck) Groups() []string {
+	return []string{"basic"}
+}
+
+// Description returns a detailed human-readable description of what this check
+// does.
+func (r *resourceRequirementsCheck) Description() string {
+	return "Check if pods have resource requirements set"
+}
+
+// Run runs this check on a set of Kubernetes objects. It can return warnings
+// (low-priority problems) and errors (high-priority problems) as well as an
+// error value indicating that the check failed to run.
+func (r *resourceRequirementsCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
+	var diagnostics []checks.Diagnostic
+
+	for _, pod := range objects.Pods.Items {
+		d := r.checkResourceRequirements(pod.Spec.Containers, pod)
+		diagnostics = append(diagnostics, d...)
+		d = r.checkResourceRequirements(pod.Spec.InitContainers, pod)
+		diagnostics = append(diagnostics, d...)
+	}
+
+	return diagnostics, nil
+}
+
+// checkImage checks if the image name is fully qualified
+// Adds a warning if the container does not use a fully qualified image name
+func (r *resourceRequirementsCheck) checkResourceRequirements(containers []corev1.Container, pod corev1.Pod) []checks.Diagnostic {
+	var diagnostics []checks.Diagnostic
+	for _, container := range containers {
+		if container.Resources.Size() == 0 {
+			d := checks.Diagnostic{
+				Check:    r.Name(),
+				Severity: checks.Warning,
+				Message:  fmt.Sprintf("Set resource requests and limits for container `%s` to prevent resource contention", container.Name),
+				Kind:     checks.Pod,
+				Object:   &pod.ObjectMeta,
+				Owners:   pod.ObjectMeta.GetOwnerReferences(),
+			}
+			diagnostics = append(diagnostics, d)
+		}
+	}
+	return diagnostics
+}

--- a/checks/basic/resource_requests_test.go
+++ b/checks/basic/resource_requests_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"testing"
+
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	resource "k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestResourceRequestsCheckMeta(t *testing.T) {
+	resourceRequirementsCheck := resourceRequirementsCheck{}
+	assert.Equal(t, "resource-requirements", resourceRequirementsCheck.Name())
+	assert.Equal(t, []string{"basic"}, resourceRequirementsCheck.Groups())
+	assert.NotEmpty(t, resourceRequirementsCheck.Description())
+}
+
+func TestResourceRequestsCheckRegistration(t *testing.T) {
+	resourceRequirementsCheck := &resourceRequirementsCheck{}
+	check, err := checks.Get("resource-requirements")
+	assert.NoError(t, err)
+	assert.Equal(t, check, resourceRequirementsCheck)
+}
+
+func TestResourceRequestsWarning(t *testing.T) {
+	const message = "Set resource requests and limits for container `bar` to prevent resource contention"
+
+	resourceRequirementsCheck := resourceRequirementsCheck{}
+
+	tests := []struct {
+		name     string
+		objs     *kube.Objects
+		expected []checks.Diagnostic
+	}{
+		{
+			name:     "no pods",
+			objs:     initPod(),
+			expected: nil,
+		},
+		{
+			name: "container with no resource requests or limits",
+			objs: container("alpine"),
+			expected: []checks.Diagnostic{
+				{
+					Check:    resourceRequirementsCheck.Name(),
+					Severity: checks.Warning,
+					Message:  message,
+					Kind:     checks.Pod,
+					Object:   GetObjectMeta(),
+					Owners:   GetOwners(),
+				},
+			},
+		},
+		{
+			name: "init container with no resource requests or limits",
+			objs: initContainer("alpine"),
+			expected: []checks.Diagnostic{
+				{
+					Check:    resourceRequirementsCheck.Name(),
+					Severity: checks.Warning,
+					Message:  message,
+					Kind:     checks.Pod,
+					Object:   GetObjectMeta(),
+					Owners:   GetOwners(),
+				},
+			},
+		},
+		{
+			name:     "resource requests set",
+			objs:     resources(),
+			expected: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d, err := resourceRequirementsCheck.Run(test.objs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, test.expected, d)
+		})
+	}
+}
+
+func resources() *kube.Objects {
+	objs := initPod()
+	objs.Pods.Items[0].Spec = corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "bar",
+				Image: "alpine",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(500, "m"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(1000, "m"),
+					},
+				},
+			}},
+		InitContainers: []corev1.Container{
+			{
+				Name:  "bar",
+				Image: "alpine",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(500, "m"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: *resource.NewQuantity(1000, "m"),
+					},
+				},
+			},
+		},
+	}
+	return objs
+
+}


### PR DESCRIPTION
When Containers have resource requests specified, the scheduler can make better decisions about which nodes to place Pods on. And when Containers have their limits specified, contention for resources on a node can be handled in a specified manner.