### PR TITLE
Allow users to configure timeout while building kubernetes client

### DIFF
--- a/checks/basic/bare_pods.go
+++ b/checks/basic/bare_pods.go
@@ -17,8 +17,6 @@ limitations under the License.
 package basic
 
 import (
-	"fmt"
-
 	"github.com/digitalocean/clusterlint/checks"
 	"github.com/digitalocean/clusterlint/kube"
 )
@@ -50,7 +48,6 @@ func (b *barePodCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
 	var diagnostics []checks.Diagnostic
 	for _, pod := range objects.Pods.Items {
 		pod := pod
-		fmt.Println(pod.ObjectMeta.OwnerReferences)
 		if len(pod.ObjectMeta.OwnerReferences) == 0 {
 			d := checks.Diagnostic{
 				Check:    b.Name(),

--- a/checks/run_checks.go
+++ b/checks/run_checks.go
@@ -17,6 +17,7 @@ limitations under the License.
 package checks
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -25,8 +26,8 @@ import (
 )
 
 // Run applies the filters and runs the resultant check list in parallel
-func Run(client *kube.Client, checkFilter CheckFilter, diagnosticFilter DiagnosticFilter) ([]Diagnostic, error) {
-	objects, err := client.FetchObjects()
+func Run(ctx context.Context, client *kube.Client, checkFilter CheckFilter, diagnosticFilter DiagnosticFilter) ([]Diagnostic, error) {
+	objects, err := client.FetchObjects(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterlint/main.go
+++ b/cmd/clusterlint/main.go
@@ -45,6 +45,10 @@ func main() {
 			Name:  "context",
 			Usage: "context for the kubernetes client. default: current context",
 		},
+		cli.StringFlag{
+			Name:  "timeout",
+			Usage: "configure timeout for the kubernetes client. default: 30s",
+		},
 	}
 	app.Commands = []cli.Command{
 		{
@@ -126,7 +130,7 @@ func listChecks(c *cli.Context) error {
 
 // runChecks runs all the checks based on the flags passed.
 func runChecks(c *cli.Context) error {
-	client, err := kube.NewClient(c.GlobalString("kubeconfig"), c.GlobalString("context"))
+	client, err := kube.NewClient(kube.WithConfigFile(c.GlobalString("kubeconfig")), kube.WithKubeContext(c.GlobalString("context")), kube.WithTimeout(c.GlobalString("timeout")))
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterlint/main.go
+++ b/cmd/clusterlint/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -34,7 +35,7 @@ import (
 func main() {
 	app := cli.NewApp()
 	app.Name = "clusterlint"
-	app.Usage = "Linter for k8sobjects from a live cluster"
+	app.Usage = "Linter for k8s objects from a live cluster"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "kubeconfig",
@@ -142,7 +143,7 @@ func runChecks(c *cli.Context) error {
 
 	diagnosticFilter := checks.DiagnosticFilter{Severity: checks.Severity(c.String("level"))}
 
-	diagnostics, err := checks.Run(client, filter, diagnosticFilter)
+	diagnostics, err := checks.Run(context.Background(), client, filter, diagnosticFilter)
 
 	write(diagnostics, c)
 

--- a/cmd/clusterlint/main.go
+++ b/cmd/clusterlint/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/digitalocean/clusterlint/checks"
 	"github.com/digitalocean/clusterlint/kube"
@@ -46,9 +47,10 @@ func main() {
 			Name:  "context",
 			Usage: "context for the kubernetes client. default: current context",
 		},
-		cli.StringFlag{
+		cli.DurationFlag{
 			Name:  "timeout",
 			Usage: "configure timeout for the kubernetes client. default: 30s",
+			Value: time.Second * 30,
 		},
 	}
 	app.Commands = []cli.Command{
@@ -131,7 +133,7 @@ func listChecks(c *cli.Context) error {
 
 // runChecks runs all the checks based on the flags passed.
 func runChecks(c *cli.Context) error {
-	client, err := kube.NewClient(kube.WithConfigFile(c.GlobalString("kubeconfig")), kube.WithKubeContext(c.GlobalString("context")), kube.WithTimeout(c.GlobalString("timeout")))
+	client, err := kube.NewClient(kube.WithConfigFile(c.GlobalString("kubeconfig")), kube.WithKubeContext(c.GlobalString("context")), kube.WithTimeout(c.GlobalDuration("timeout")))
 	if err != nil {
 		return err
 	}

--- a/kube/objects.go
+++ b/kube/objects.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kube
 
 import (
+	"context"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -27,6 +28,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+const defaultTimeout = "30s"
 
 //Identifier is used to identify a specific namspace scoped object.
 type Identifier struct {
@@ -59,7 +62,8 @@ type Client struct {
 }
 
 // FetchObjects returns the objects from a Kubernetes cluster.
-func (c *Client) FetchObjects() (*Objects, error) {
+// ctx is currently unused during API calls. More info: https://github.com/kubernetes/community/pull/1166
+func (c *Client) FetchObjects(ctx context.Context) (*Objects, error) {
 	client := c.KubeClient.CoreV1()
 	admissionControllerClient := c.KubeClient.AdmissionregistrationV1beta1()
 	opts := metav1.ListOptions{}
@@ -140,7 +144,7 @@ func (c *Client) FetchObjects() (*Objects, error) {
 // The kube config file path or the kubeconfig yaml must be specified
 // If not specified, defaults are assumed - configPath: ~/.kube/config, configContext: current context
 func NewClient(opts ...Option) (*Client, error) {
-	timeout, _ := time.ParseDuration("30s")
+	timeout, _ := time.ParseDuration(defaultTimeout)
 	defOpts := &options{
 		timeout: timeout,
 	}

--- a/kube/objects_test.go
+++ b/kube/objects_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kube
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,7 +38,7 @@ func TestFetchObjects(t *testing.T) {
 			Labels: map[string]string{"doks_key": "bar"}},
 	})
 
-	actual, err := api.FetchObjects()
+	actual, err := api.FetchObjects(context.Background())
 	assert.NoError(t, err)
 
 	assert.NotNil(t, actual.Nodes)

--- a/kube/objects_test.go
+++ b/kube/objects_test.go
@@ -18,6 +18,7 @@ package kube
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,4 +57,13 @@ func TestFetchObjects(t *testing.T) {
 	assert.NotNil(t, actual.ValidatingWebhookConfigurations)
 	assert.NotNil(t, actual.MutatingWebhookConfigurations)
 	assert.NotNil(t, actual.SystemNamespace)
+}
+
+func TestNewClientErrors(t *testing.T) {
+	// test both yaml and filepath specified
+	_, err := NewClient(WithConfigFile("some-path"), WithYaml([]byte("yaml")))
+	assert.Equal(t, errors.New("cannot specify both yaml and kubeconfg file path"), err)
+	// test no authentication mechanism
+	_, err = NewClient()
+	assert.Equal(t, errors.New("cannot authenticate Kubernetes API requests"), err)
 }

--- a/kube/options.go
+++ b/kube/options.go
@@ -53,17 +53,9 @@ func WithYaml(yaml []byte) Option {
 }
 
 // WithTimeout returns an Option injected with a timeout option while building client.
-// A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix,
-// such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-func WithTimeout(t string) Option {
+func WithTimeout(t time.Duration) Option {
 	return func(o *options) error {
-		if t != "" {
-			timeout, err := time.ParseDuration(t)
-			if err != nil {
-				return err
-			}
-			o.timeout = timeout
-		}
+		o.timeout = t
 		return nil
 	}
 }

--- a/kube/options.go
+++ b/kube/options.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import "time"
+
+type options struct {
+	path        string
+	kubeContext string
+	yaml        []byte
+	timeout     time.Duration
+}
+
+// Option function that allows injecting options while building kube.Client.
+type Option func(*options) error
+
+// WithConfigFile returns an Option injected with a config file path.
+func WithConfigFile(path string) Option {
+	return func(o *options) error {
+		o.path = path
+		return nil
+	}
+}
+
+// WithKubeContext returns an Option injected with a kubernetes context.
+func WithKubeContext(kubeContext string) Option {
+	return func(o *options) error {
+		o.kubeContext = kubeContext
+		return nil
+	}
+}
+
+// WithYaml returns an Option injected with a kubeconfig yaml.
+func WithYaml(yaml []byte) Option {
+	return func(o *options) error {
+		o.yaml = yaml
+		return nil
+	}
+}
+
+// WithTimeout returns an Option injected with a timeout option while building client.
+// A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix,
+// such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+func WithTimeout(t string) Option {
+	return func(o *options) error {
+		if t != "" {
+			timeout, err := time.ParseDuration(t)
+			if err != nil {
+				return err
+			}
+			o.timeout = timeout
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
Issue: #38

There is a proposal upstream to introduce context for API calls: https://github.com/kubernetes/community/pull/1166. So, to accommodate that, the `checks.Run` API takes in a context currently, but is unused.