### PR TITLE
Check KUBECONFIG env var while building client

### DIFF
--- a/cmd/clusterlint/main.go
+++ b/cmd/clusterlint/main.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -141,8 +140,6 @@ func runChecks(c *cli.Context) error {
 		kubeconfigFilePaths = []string{kubeconfig}
 	} else if value := os.Getenv("KUBECONFIG"); value != "" {
 		kubeconfigFilePaths = strings.Split(value, delimiter)
-	} else {
-		kubeconfigFilePaths = []string{filepath.Join(os.Getenv("HOME"), ".kube", "config")}
 	}
 
 	client, err := kube.NewClient(kube.WithMergedConfigFiles(kubeconfigFilePaths), kube.WithKubeContext(c.GlobalString("context")), kube.WithTimeout(c.GlobalDuration("timeout")))

--- a/kube/objects.go
+++ b/kube/objects.go
@@ -18,7 +18,6 @@ package kube
 
 import (
 	"context"
-	"errors"
 
 	"golang.org/x/sync/errgroup"
 	ar "k8s.io/api/admissionregistration/v1beta1"
@@ -159,15 +158,16 @@ func NewClient(opts ...Option) (*Client, error) {
 
 	if defOpts.yaml != nil {
 		config, err = clientcmd.RESTConfigFromKubeConfig(defOpts.yaml)
-	} else if len(defOpts.paths) != 0 {
-		loadingRules := &clientcmd.ClientConfigLoadingRules{Precedence: defOpts.paths}
+	} else {
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		if len(defOpts.paths) != 0 {
+			loadingRules.Precedence = defOpts.paths
+		}
 		configOverrides := &clientcmd.ConfigOverrides{}
 		if defOpts.kubeContext != "" {
 			configOverrides.CurrentContext = defOpts.kubeContext
 		}
 		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
-	} else {
-		err = errors.New("cannot authenticate Kubernetes API requests")
 	}
 
 	if err != nil {

--- a/kube/objects_test.go
+++ b/kube/objects_test.go
@@ -61,9 +61,18 @@ func TestFetchObjects(t *testing.T) {
 
 func TestNewClientErrors(t *testing.T) {
 	// test both yaml and filepath specified
-	_, err := NewClient(WithConfigFile("some-path"), WithYaml([]byte("yaml")))
-	assert.Equal(t, errors.New("cannot specify both yaml and kubeconfg file path"), err)
-	// test no authentication mechanism
-	_, err = NewClient()
-	assert.Equal(t, errors.New("cannot authenticate Kubernetes API requests"), err)
+	t.Run("both yaml and filepath specified", func(t *testing.T) {
+		_, err := NewClient(WithConfigFile("some-path"), WithYaml([]byte("yaml")))
+		assert.Equal(t, errors.New("cannot specify yaml and kubeconfig file paths"), err)
+	})
+
+	t.Run("both yaml and KUBECONFIG specified", func(t *testing.T) {
+		_, err := NewClient(WithMergedConfigFiles([]string{"some-path"}), WithYaml([]byte("yaml")))
+		assert.Equal(t, errors.New("cannot specify yaml and kubeconfig file paths"), err)
+	})
+
+	t.Run("no authentication mechanism", func(t *testing.T) {
+		_, err := NewClient()
+		assert.Equal(t, errors.New("cannot authenticate Kubernetes API requests"), err)
+	})
 }

--- a/kube/objects_test.go
+++ b/kube/objects_test.go
@@ -60,7 +60,6 @@ func TestFetchObjects(t *testing.T) {
 }
 
 func TestNewClientErrors(t *testing.T) {
-	// test both yaml and filepath specified
 	t.Run("both yaml and filepath specified", func(t *testing.T) {
 		_, err := NewClient(WithConfigFile("some-path"), WithYaml([]byte("yaml")))
 		assert.Equal(t, errors.New("cannot specify yaml and kubeconfig file paths"), err)
@@ -69,10 +68,5 @@ func TestNewClientErrors(t *testing.T) {
 	t.Run("both yaml and KUBECONFIG specified", func(t *testing.T) {
 		_, err := NewClient(WithMergedConfigFiles([]string{"some-path"}), WithYaml([]byte("yaml")))
 		assert.Equal(t, errors.New("cannot specify yaml and kubeconfig file paths"), err)
-	})
-
-	t.Run("no authentication mechanism", func(t *testing.T) {
-		_, err := NewClient()
-		assert.Equal(t, errors.New("cannot authenticate Kubernetes API requests"), err)
 	})
 }


### PR DESCRIPTION
* Precedence: kubeconfig cli option > KUBECONFIG env var > $HOME/.kube/config
* If yaml and kubeconfig file path are set, throw an error