### PR TITLE
Provide check duration time in json output

### DIFF
--- a/checks/run_checks.go
+++ b/checks/run_checks.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context, client *kube.Client, checkFilter CheckFilter, diag
 	var diagnostics []Diagnostic
 	var mu sync.Mutex
 	var g errgroup.Group
-	checkDuration := make(map[string]string)
+	checkDuration := make(map[string]time.Duration)
 	for _, check := range all {
 		check := check
 		g.Go(func() error {
@@ -55,7 +55,7 @@ func Run(ctx context.Context, client *kube.Client, checkFilter CheckFilter, diag
 			}
 			mu.Lock()
 			diagnostics = append(diagnostics, d...)
-			checkDuration[check.Name()] = elapsed.String()
+			checkDuration[check.Name()] = elapsed
 			mu.Unlock()
 			return nil
 		})
@@ -96,5 +96,5 @@ func filterSeverity(level Severity, diagnostics []Diagnostic) []Diagnostic {
 // CheckResult is the output returned by the Run function
 type CheckResult struct {
 	Diagnostics []Diagnostic
-	Durations   map[string]string
+	Durations   map[string]time.Duration
 }

--- a/checks/run_checks.go
+++ b/checks/run_checks.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/digitalocean/clusterlint/kube"
 	"golang.org/x/sync/errgroup"
 )
 
 // Run applies the filters and runs the resultant check list in parallel
-func Run(ctx context.Context, client *kube.Client, checkFilter CheckFilter, diagnosticFilter DiagnosticFilter) ([]Diagnostic, error) {
+func Run(ctx context.Context, client *kube.Client, checkFilter CheckFilter, diagnosticFilter DiagnosticFilter) (*CheckResult, error) {
 	objects, err := client.FetchObjects(ctx)
 	if err != nil {
 		return nil, err
@@ -42,16 +43,19 @@ func Run(ctx context.Context, client *kube.Client, checkFilter CheckFilter, diag
 	var diagnostics []Diagnostic
 	var mu sync.Mutex
 	var g errgroup.Group
-
+	checkDuration := make(map[string]string)
 	for _, check := range all {
 		check := check
 		g.Go(func() error {
+			start := time.Now()
 			d, err := check.Run(objects)
+			elapsed := time.Since(start)
 			if err != nil {
 				return err
 			}
 			mu.Lock()
 			diagnostics = append(diagnostics, d...)
+			checkDuration[check.Name()] = elapsed.String()
 			mu.Unlock()
 			return nil
 		})
@@ -62,7 +66,8 @@ func Run(ctx context.Context, client *kube.Client, checkFilter CheckFilter, diag
 	}
 	diagnostics = filterEnabled(diagnostics)
 	diagnostics = filterSeverity(diagnosticFilter.Severity, diagnostics)
-	return diagnostics, err
+	CheckResult := &CheckResult{Diagnostics: diagnostics, Durations: checkDuration}
+	return CheckResult, err
 }
 
 func filterEnabled(diagnostics []Diagnostic) []Diagnostic {
@@ -86,4 +91,10 @@ func filterSeverity(level Severity, diagnostics []Diagnostic) []Diagnostic {
 		}
 	}
 	return ret
+}
+
+// CheckResult is the output returned by the Run function
+type CheckResult struct {
+	Diagnostics []Diagnostic
+	Durations   map[string]string
 }

--- a/cmd/clusterlint/main.go
+++ b/cmd/clusterlint/main.go
@@ -145,19 +145,21 @@ func runChecks(c *cli.Context) error {
 
 	diagnosticFilter := checks.DiagnosticFilter{Severity: checks.Severity(c.String("level"))}
 
-	diagnostics, err := checks.Run(context.Background(), client, filter, diagnosticFilter)
+	output, err := checks.Run(context.Background(), client, filter, diagnosticFilter)
+	if err != nil {
+		return err
+	}
+	write(output, c)
 
-	write(diagnostics, c)
-
-	return err
+	return nil
 }
 
-func write(diagnostics []checks.Diagnostic, c *cli.Context) error {
+func write(checkResult *checks.CheckResult, c *cli.Context) error {
 	output := c.String("output")
 
 	switch output {
 	case "json":
-		err := json.NewEncoder(os.Stdout).Encode(diagnostics)
+		err := json.NewEncoder(os.Stdout).Encode(checkResult)
 		if err != nil {
 			return err
 		}
@@ -168,7 +170,7 @@ func write(diagnostics []checks.Diagnostic, c *cli.Context) error {
 		e := color.New(color.FgRed)
 		w := color.New(color.FgYellow)
 		s := color.New(color.FgBlue)
-		for _, d := range diagnostics {
+		for _, d := range checkResult.Diagnostics {
 			switch d.Severity {
 			case checks.Error:
 				e.Println(d)


### PR DESCRIPTION
Sample json:

```json
"Durations": {
    "admission-controller-webhook": "5.193µs",
    "bare-pods": "12.363µs",
    "default-namespace": "31.826µs",
    "fully-qualified-image": "224.87µs",
    "hostpath-volume": "86.482µs",
    "latest-tag": "158.023µs",
    "node-name-pod-selector": "9.108µs",
    "non-root-user": "44.107µs",
    "noop": "310ns",
    "pod-state": "9.036µs",
    "privileged-containers": "56.992µs",
    "resource-requirements": "97.013µs",
    "unused-config-map": "149.937µs",
    "unused-pv": "33.115µs",
    "unused-pvc": "49.56µs",
    "unused-secret": "139.136µs"
}
```

@adamwg - last Friday we identified that the API requests are the reason for the tool being slow.  Do we want to maybe wait on https://github.com/digitalocean/clusterlint/pull/48 for some perf tests while we assess if the PR is really required? 