### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This also documents some of the recommended practices to follow while writing th
 ### Install
 
 ```bash
-go install ./cmd/clusterlint
+go get github.com/digitalocean/clusterlint/cmd/clusterlint
 ```
 
 The above command creates the `clusterlint` binary in `$GOPATH/bin`


### PR DESCRIPTION
The installation instructions assume the user has the repo cloned in the CWD.
I've updated them to a generic command that should be work for any person with Go installed.

I think the current instruction might be more suitable if a development guide was added?