### PR TITLE
Change severity levels for some checks

### DIFF
--- a/checks/basic/bare_pods.go
+++ b/checks/basic/bare_pods.go
@@ -51,7 +51,7 @@ func (b *barePodCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
 		if len(pod.ObjectMeta.OwnerReferences) == 0 {
 			d := checks.Diagnostic{
 				Check:    b.Name(),
-				Severity: checks.Error,
+				Severity: checks.Warning,
 				Message:  "Avoid using bare pods in clusters",
 				Kind:     checks.Pod,
 				Object:   &pod.ObjectMeta,

--- a/checks/basic/bare_pods_test.go
+++ b/checks/basic/bare_pods_test.go
@@ -66,7 +66,7 @@ func TestBarePodError(t *testing.T) {
 			objs: initPod(),
 			expected: []checks.Diagnostic{
 				{
-					Severity: "error",
+					Severity: "warning",
 					Check:    "bare-pods",
 					Kind:     checks.Pod,
 					Message:  "Avoid using bare pods in clusters",
@@ -80,7 +80,7 @@ func TestBarePodError(t *testing.T) {
 			objs: initMultiplePods(),
 			expected: []checks.Diagnostic{
 				{
-					Severity: "error",
+					Severity: "warning",
 					Check:    "bare-pods",
 					Kind:     checks.Pod,
 					Message:  "Avoid using bare pods in clusters",
@@ -88,7 +88,7 @@ func TestBarePodError(t *testing.T) {
 					Owners:   nil,
 				},
 				{
-					Severity: "error",
+					Severity: "warning",
 					Check:    "bare-pods",
 					Kind:     checks.Pod,
 					Message:  "Avoid using bare pods in clusters",

--- a/checks/basic/fully_qualified_image.go
+++ b/checks/basic/fully_qualified_image.go
@@ -72,7 +72,7 @@ func (fq *fullyQualifiedImageCheck) checkImage(containers []corev1.Container, po
 		if err != nil {
 			d := checks.Diagnostic{
 				Check:    fq.Name(),
-				Severity: checks.Error,
+				Severity: checks.Warning,
 				Message:  fmt.Sprintf("Malformed image name for container '%s'", container.Name),
 				Kind:     checks.Pod,
 				Object:   &pod.ObjectMeta,

--- a/checks/basic/fully_qualified_image_test.go
+++ b/checks/basic/fully_qualified_image_test.go
@@ -148,7 +148,7 @@ func TestFullyQualifiedImageWarning(t *testing.T) {
 
 func TestMalformedImageError(t *testing.T) {
 	const message = "Malformed image name for container 'bar'"
-	const severity = checks.Error
+	const severity = checks.Warning
 	const name = "fully-qualified-image"
 
 	tests := []struct {

--- a/checks/basic/hostpath.go
+++ b/checks/basic/hostpath.go
@@ -56,7 +56,7 @@ func (h *hostPathCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) 
 			if volume.VolumeSource.HostPath != nil {
 				d := checks.Diagnostic{
 					Check:    h.Name(),
-					Severity: checks.Error,
+					Severity: checks.Warning,
 					Message:  fmt.Sprintf("Avoid using hostpath for volume '%s'.", volume.Name),
 					Kind:     checks.Pod,
 					Object:   &pod.ObjectMeta,

--- a/checks/basic/hostpath_test.go
+++ b/checks/basic/hostpath_test.go
@@ -70,7 +70,7 @@ func TestHostpathVolumeError(t *testing.T) {
 			expected: []checks.Diagnostic{
 				{
 					Check:    "hostpath-volume",
-					Severity: checks.Error,
+					Severity: checks.Warning,
 					Message:  "Avoid using hostpath for volume 'bar'.",
 					Kind:     checks.Pod,
 					Object:   GetObjectMeta(),

--- a/checks/doks/node_name_pod_selector.go
+++ b/checks/doks/node_name_pod_selector.go
@@ -54,7 +54,7 @@ func (p *podSelectorCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, erro
 		if _, ok := nodeSelectorMap[corev1.LabelHostname]; ok {
 			d := checks.Diagnostic{
 				Check:    p.Name(),
-				Severity: checks.Error,
+				Severity: checks.Warning,
 				Message:  "Avoid node name label for node selector.",
 				Kind:     checks.Pod,
 				Object:   &pod.ObjectMeta,

--- a/checks/doks/node_name_pod_selector_test.go
+++ b/checks/doks/node_name_pod_selector_test.go
@@ -56,7 +56,7 @@ func TestNodeNameError(t *testing.T) {
 		{
 			name:     "node name used in node selector",
 			objs:     invalidPod(),
-			expected: errors(invalidPod(), podSelectorCheck.Name()),
+			expected: warnings(invalidPod(), podSelectorCheck.Name()),
 		},
 	}
 
@@ -89,12 +89,12 @@ func invalidPod() *kube.Objects {
 	return objs
 }
 
-func errors(objs *kube.Objects, name string) []checks.Diagnostic {
+func warnings(objs *kube.Objects, name string) []checks.Diagnostic {
 	pod := objs.Pods.Items[0]
 	diagnostics := []checks.Diagnostic{
 		{
 			Check:    name,
-			Severity: checks.Error,
+			Severity: checks.Warning,
 			Message:  "Avoid node name label for node selector.",
 			Kind:     checks.Pod,
 			Object:   &pod.ObjectMeta,


### PR DESCRIPTION
* If a check causes upgrade or node replacement to break, severity level is error, else warning

Based on https://github.com/digitalocean/clusterlint/pull/54#discussion_r322867794, edited the severity levels for checks. 
