### PR TITLE
Add bare-pods and hostpath-volume to doks group

### DIFF
--- a/checks/basic/bare_pods.go
+++ b/checks/basic/bare_pods.go
@@ -34,7 +34,7 @@ func (b *barePodCheck) Name() string {
 
 // Groups returns a list of group names this check should be part of.
 func (b *barePodCheck) Groups() []string {
-	return []string{"basic"}
+	return []string{"basic", "doks"}
 }
 
 // Description returns a detailed human-readable description of what this check

--- a/checks/basic/bare_pods_test.go
+++ b/checks/basic/bare_pods_test.go
@@ -29,7 +29,7 @@ import (
 func TestBarePodCheckMeta(t *testing.T) {
 	barePodCheck := barePodCheck{}
 	assert.Equal(t, "bare-pods", barePodCheck.Name())
-	assert.Equal(t, []string{"basic"}, barePodCheck.Groups())
+	assert.Equal(t, []string{"basic", "doks"}, barePodCheck.Groups())
 	assert.NotEmpty(t, barePodCheck.Description())
 }
 

--- a/checks/basic/hostpath.go
+++ b/checks/basic/hostpath.go
@@ -36,7 +36,7 @@ func (h *hostPathCheck) Name() string {
 
 // Groups returns a list of group names this check should be part of.
 func (h *hostPathCheck) Groups() []string {
-	return []string{"basic"}
+	return []string{"basic", "doks"}
 }
 
 // Description returns a detailed human-readable description of what this check

--- a/checks/basic/hostpath_test.go
+++ b/checks/basic/hostpath_test.go
@@ -28,7 +28,7 @@ import (
 func TestHostpathCheckMeta(t *testing.T) {
 	hostPathCheck := hostPathCheck{}
 	assert.Equal(t, "hostpath-volume", hostPathCheck.Name())
-	assert.Equal(t, []string{"basic"}, hostPathCheck.Groups())
+	assert.Equal(t, []string{"basic", "doks"}, hostPathCheck.Groups())
 	assert.NotEmpty(t, hostPathCheck.Description())
 }
 


### PR DESCRIPTION
* Checks is doks group are run by default on DOKS

doks group now has:
- bare-pods,
- hostpath-volume,
- node-labels-and-taints
- admission-controller-webhook
- node-name-pod-selector

@adamwg - we didn't discuss `node-name-pod-selector` as part of the checks run during upgrade on DOKS. But, I think it should be there, similar to `node-labels-and-taints`. Even though it doesn't generate an error that would break upgrade, upgrade affects workloads that these checks identify. 