### PR TITLE
Update the DOKS admission controller webhook check

### DIFF
--- a/checks/doks/node_name_pod_selector_test.go
+++ b/checks/doks/node_name_pod_selector_test.go
@@ -56,7 +56,7 @@ func TestNodeNameError(t *testing.T) {
 		{
 			name:     "node name used in node selector",
 			objs:     invalidPod(),
-			expected: warnings(invalidPod(), podSelectorCheck.Name()),
+			expected: expectedWarnings(invalidPod(), podSelectorCheck.Name()),
 		},
 	}
 
@@ -89,7 +89,7 @@ func invalidPod() *kube.Objects {
 	return objs
 }
 
-func warnings(objs *kube.Objects, name string) []checks.Diagnostic {
+func expectedWarnings(objs *kube.Objects, name string) []checks.Diagnostic {
 	pod := objs.Pods.Items[0]
 	diagnostics := []checks.Diagnostic{
 		{

--- a/kube/objects.go
+++ b/kube/objects.go
@@ -54,6 +54,7 @@ type Objects struct {
 	LimitRanges                     *corev1.LimitRangeList
 	MutatingWebhookConfigurations   *ar.MutatingWebhookConfigurationList
 	ValidatingWebhookConfigurations *ar.ValidatingWebhookConfigurationList
+	Namespaces                      *corev1.NamespaceList
 }
 
 // Client encapsulates a client for a Kubernetes cluster.
@@ -129,6 +130,10 @@ func (c *Client) FetchObjects(ctx context.Context) (*Objects, error) {
 	})
 	g.Go(func() (err error) {
 		objects.ValidatingWebhookConfigurations, err = admissionControllerClient.ValidatingWebhookConfigurations().List(opts)
+		return
+	})
+	g.Go(func() (err error) {
+		objects.Namespaces, err = client.Namespaces().List(opts)
 		return
 	})
 


### PR DESCRIPTION
DOKS has improved handling of webhooks such that the only webhooks that cause problems are those that:

* Have failurePolicy set to Fail,
* Target a service other than the Kubernetes apiserver, and
* Apply kube-system, and
* Applies to the namespace of the targeted service or are in a single-node cluster.

Update the webhook check to reflect this improvement.