### PR TITLE
kube: allow wrapping the underlying http.RoundTripper

### DIFF
--- a/kube/objects.go
+++ b/kube/objects.go
@@ -182,6 +182,10 @@ func NewClient(opts ...Option) (*Client, error) {
 		return nil, err
 	}
 	config.Timeout = defOpts.timeout
+	if defOpts.transportWrapper != nil {
+		config.Wrap(defOpts.transportWrapper)
+	}
+
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/kube/options.go
+++ b/kube/options.go
@@ -18,16 +18,18 @@ package kube
 
 import (
 	"errors"
+	"net/http"
 	"time"
 )
 
 const delimiter = ":"
 
 type options struct {
-	paths       []string
-	kubeContext string
-	yaml        []byte
-	timeout     time.Duration
+	paths            []string
+	kubeContext      string
+	yaml             []byte
+	transportWrapper TransportWrapper
+	timeout          time.Duration
 }
 
 // Option function that allows injecting options while building kube.Client.
@@ -69,6 +71,17 @@ func WithMergedConfigFiles(paths []string) Option {
 func WithTimeout(t time.Duration) Option {
 	return func(o *options) error {
 		o.timeout = t
+		return nil
+	}
+}
+
+// TransportWrapper wraps an http.RoundTripper
+type TransportWrapper = func(http.RoundTripper) http.RoundTripper
+
+// WithTransportWrapper allows wrapping the underlying http.RoundTripper
+func WithTransportWrapper(f TransportWrapper) Option {
+	return func(o *options) error {
+		o.transportWrapper = f
 		return nil
 	}
 }


### PR DESCRIPTION
To get more control over the underlying `http.Transport` this PR adds a WithTransportWrapper Option that will allow the caller to pass in a function that's used to wrap the http.RoundTripper. This will allow us to access the *http.Transport and close the connections after we're done linting.