### PR TITLE
checks/latest-tag: Handle unparseable image names

### DIFF
--- a/checks/basic/latest_tag_test.go
+++ b/checks/basic/latest_tag_test.go
@@ -40,6 +40,7 @@ func TestLatestTagCheckRegistration(t *testing.T) {
 
 func TestLatestTagWarning(t *testing.T) {
 	const message = "Avoid using latest tag for container 'bar'"
+	const invalidMessage = "Image name for container 'bar' could not be parsed"
 	const severity = checks.Warning
 	const name = "latest-tag"
 
@@ -153,6 +154,16 @@ func TestLatestTagWarning(t *testing.T) {
 			name:     "pod with init container image - busybox:v1.2.3",
 			objs:     initContainer("busybox:v1.2.3"),
 			expected: nil,
+		},
+		{
+			name:     "pod with init container with invalid image name",
+			objs:     initContainer(""),
+			expected: issues(severity, invalidMessage, checks.Pod, name),
+		},
+		{
+			name:     "pod with container with invalid image name",
+			objs:     container(""),
+			expected: issues(severity, invalidMessage, checks.Pod, name),
 		},
 	}
 


### PR DESCRIPTION
We don't expect to see unparseable image names in running pods, since k8s was able to parse all the image names when the pod was created. However, that appears to be what's happening in #71, so we should handle the case to avoid dereferencing a nil pointer.