### PR TITLE
Add support for local checks via Go plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ truly specific check that is not appropriate for sharing with the broader
 community, you can implement it using Go plugins.
 
 See the [example plugin](example-plugin) for documentation on how to build a
-plugin.
+plugin. Please be sure to read the [caveats](example-plugin/README.md#caveats)
+and consider whether you really want to maintain a plugin.
 
 To use your plugin with clusterlint, pass its path on the commandline:
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ Clusterlint provides a way to ignore some special objects in the cluster from be
 }
 ```
 
+### Building local checks
+
+Some individuals and organizations have Kubernetes best practices that are not
+applicable to the general community, but which they would like to check with
+clusterlint. If your check may be useful for *anyone* else, we encourage you to
+submit it to clusterlint rather than keeping it local. However, if you have a
+truly specific check that is not appropriate for sharing with the broader
+community, you can implement it using Go plugins.
+
+See the [example plugin](example-plugin) for documentation on how to build a
+plugin.
+
+To use your plugin with clusterlint, pass its path on the commandline:
+
+```console
+$ clusterlint --plugins=/path/to/plugin.so list
+$ clusterlint --plugins=/path/to/plugin.so run -c my-plugin-check
+```
+
 ## Contributing
 
 Contributions are welcome, in the form of either issues or pull requests. Please

--- a/example-plugin/README.md
+++ b/example-plugin/README.md
@@ -1,0 +1,42 @@
+# Example Check Plugin
+
+This directory contains an example of a check plugin for clusterlint. Plugins
+can be used to implement checks that are not appropriate for addition to
+clusterlint itself for whatever reason - e.g., because they encode a best
+practice that is highly specific to a particular organization.
+
+## Building
+
+Build the plugin as a Go plugin:
+
+```console
+$ go build -buildmode=plugin github.com/digitalocean/clusterlint/example-plugin
+```
+
+You should end up with a file called `example-plugin.so` in your working
+directory.
+
+## Usage
+
+You can then use the plugin by loading it into clusterlint at runtime:
+
+```console
+$ clusterlint --plugins=./example-plugin.so run -c example-plugin
+[suggestion] kube-system/pod/kubelet-rubber-stamp-f6756bc78-6sl9r: You probably don't want to run the example plugin.
+```
+
+The example plugin produces a suggestion for each pod running in the cluster,
+just to show what a plugin can do.
+
+## Troubleshooting
+
+The easiest problem to hit with plugins is trying to use a plugin built against
+a different version of the clusterlint codebase than the clusterlint binary
+you're using. In this case, you'll get a message like:
+
+```
+plugin.Open("./example-plugin"): plugin was built with a different version of package github.com/digitalocean/clusterlint/kube
+```
+
+We recommend using go module versioning to ensure you're building your plugin
+against code from the clusterlint release you're using.

--- a/example-plugin/README.md
+++ b/example-plugin/README.md
@@ -28,15 +28,26 @@ $ clusterlint --plugins=./example-plugin.so run -c example-plugin
 The example plugin produces a suggestion for each pod running in the cluster,
 just to show what a plugin can do.
 
-## Troubleshooting
+## Caveats
 
-The easiest problem to hit with plugins is trying to use a plugin built against
-a different version of the clusterlint codebase than the clusterlint binary
-you're using. In this case, you'll get a message like:
+### Supported Platforms
+
+Go plugins are [supported only on Linux and macOS](https://golang.org/pkg/plugin/#pkg-overview).
+
+### Versioning
+
+Plugins **must** be built against the exact same version of the clusterlint
+codebase as the clusterlint binary you are using, as well as against the same
+version of all dependencies.
+
+If the version used to build the plugin doesn't match the binary version you'll
+get a message like:
 
 ```
 plugin.Open("./example-plugin"): plugin was built with a different version of package github.com/digitalocean/clusterlint/kube
 ```
 
 We recommend using go module versioning to ensure you're building your plugin
-against code from the clusterlint release you're using.
+against code from the clusterlint release you're using. If you build clusterlint
+using the vendored dependencies, make sure you also build your plugins using the
+vendored dependencies.

--- a/example-plugin/plugin.go
+++ b/example-plugin/plugin.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+)
+
+type check struct{}
+
+// Name returns a unique name for this check.
+func (nc *check) Name() string {
+	return "example-plugin"
+}
+
+// Groups returns a list of group names this check should be part of.
+func (nc *check) Groups() []string {
+	return []string{"examples"}
+}
+
+// Description returns a detailed human-readable description of what this check
+// does.
+func (nc *check) Description() string {
+	return "A sample plugin."
+}
+
+// Run runs this check on a set of Kubernetes objects.
+func (nc *check) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
+	d := make([]checks.Diagnostic, len(objects.Pods.Items))
+	for i, p := range objects.Pods.Items {
+		d[i] = checks.Diagnostic{
+			Message:  "You probably don't want to run the example plugin.",
+			Severity: checks.Suggestion,
+			Kind:     checks.Pod,
+			Object:   &p.ObjectMeta,
+			Owners:   p.GetOwnerReferences(),
+		}
+	}
+	return d, nil
+}
+
+func init() {
+	checks.Register(&check{})
+}


### PR DESCRIPTION
We've had questions a few times about whether it's possible to implement organization-specific checks that are not appropriate for inclusion in the clusterlint codebase. For example, a company may have some highly specific best practice that isn't relevant anywhere else, but want to enforce it using clusterlint alongside all their other best practices.

Implement this capability by allowing Go plugins to be loaded into clusterlint at runtime. Document how to build plugins, and provide an example.