### PR TITLE
Fix reference to loop variables in doks admission controller checks

### DIFF
--- a/checks/doks/admission_controller_webhook_replacement.go
+++ b/checks/doks/admission_controller_webhook_replacement.go
@@ -53,8 +53,10 @@ func (w *webhookReplacementCheck) Run(objects *kube.Objects) ([]checks.Diagnosti
 
 	var diagnostics []checks.Diagnostic
 
-	for _, config := range objects.ValidatingWebhookConfigurations.Items {
-		for _, wh := range config.Webhooks {
+	for i := range objects.ValidatingWebhookConfigurations.Items {
+		config := objects.ValidatingWebhookConfigurations.Items[i]
+		for k := range config.Webhooks {
+			wh := config.Webhooks[k]
 			if *wh.FailurePolicy == ar.Ignore {
 				// Webhooks with failurePolicy: Ignore are fine.
 				continue
@@ -73,7 +75,8 @@ func (w *webhookReplacementCheck) Run(objects *kube.Objects) ([]checks.Diagnosti
 				continue
 			}
 			var svcNamespace *v1.Namespace
-			for _, ns := range objects.Namespaces.Items {
+			for i := range objects.Namespaces.Items {
+				ns := objects.Namespaces.Items[i]
 				if ns.Name == wh.ClientConfig.Service.Namespace {
 					svcNamespace = &ns
 				}
@@ -102,8 +105,10 @@ func (w *webhookReplacementCheck) Run(objects *kube.Objects) ([]checks.Diagnosti
 		}
 	}
 
-	for _, config := range objects.MutatingWebhookConfigurations.Items {
-		for _, wh := range config.Webhooks {
+	for i := range objects.MutatingWebhookConfigurations.Items {
+		config := objects.MutatingWebhookConfigurations.Items[i]
+		for k := range config.Webhooks {
+			wh := config.Webhooks[k]
 			if *wh.FailurePolicy == ar.Ignore {
 				// Webhooks with failurePolicy: Ignore are fine.
 				continue

--- a/checks/doks/admission_controller_webhook_replacement.go
+++ b/checks/doks/admission_controller_webhook_replacement.go
@@ -53,10 +53,10 @@ func (w *webhookReplacementCheck) Run(objects *kube.Objects) ([]checks.Diagnosti
 
 	var diagnostics []checks.Diagnostic
 
-	for i := range objects.ValidatingWebhookConfigurations.Items {
-		config := objects.ValidatingWebhookConfigurations.Items[i]
-		for k := range config.Webhooks {
-			wh := config.Webhooks[k]
+	for _, config := range objects.ValidatingWebhookConfigurations.Items {
+		config := config
+		for _, wh := range config.Webhooks {
+			wh := wh
 			if *wh.FailurePolicy == ar.Ignore {
 				// Webhooks with failurePolicy: Ignore are fine.
 				continue
@@ -75,8 +75,8 @@ func (w *webhookReplacementCheck) Run(objects *kube.Objects) ([]checks.Diagnosti
 				continue
 			}
 			var svcNamespace *v1.Namespace
-			for i := range objects.Namespaces.Items {
-				ns := objects.Namespaces.Items[i]
+			for _, ns := range objects.Namespaces.Items {
+				ns := ns
 				if ns.Name == wh.ClientConfig.Service.Namespace {
 					svcNamespace = &ns
 				}
@@ -105,10 +105,10 @@ func (w *webhookReplacementCheck) Run(objects *kube.Objects) ([]checks.Diagnosti
 		}
 	}
 
-	for i := range objects.MutatingWebhookConfigurations.Items {
-		config := objects.MutatingWebhookConfigurations.Items[i]
-		for k := range config.Webhooks {
-			wh := config.Webhooks[k]
+	for _, config := range objects.MutatingWebhookConfigurations.Items {
+		config := config
+		for _, wh := range config.Webhooks {
+			wh := wh
 			if *wh.FailurePolicy == ar.Ignore {
 				// Webhooks with failurePolicy: Ignore are fine.
 				continue
@@ -128,6 +128,7 @@ func (w *webhookReplacementCheck) Run(objects *kube.Objects) ([]checks.Diagnosti
 			}
 			var svcNamespace *v1.Namespace
 			for _, ns := range objects.Namespaces.Items {
+				ns := ns
 				if ns.Name == wh.ClientConfig.Service.Namespace {
 					svcNamespace = &ns
 				}

--- a/checks/doks/admission_controller_webhook_timeout.go
+++ b/checks/doks/admission_controller_webhook_timeout.go
@@ -47,10 +47,10 @@ func (w *webhookTimeoutCheck) Description() string {
 func (w *webhookTimeoutCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
 	var diagnostics []checks.Diagnostic
 
-	for i := range objects.ValidatingWebhookConfigurations.Items {
-		config := objects.ValidatingWebhookConfigurations.Items[i]
-		for k := range config.Webhooks {
-			wh := config.Webhooks[k]
+	for _, config := range objects.ValidatingWebhookConfigurations.Items {
+		config := config
+		for _, wh := range config.Webhooks {
+			wh := wh
 			if wh.TimeoutSeconds == nil {
 				// TimeoutSeconds value should be set to a non-nil value (greater than or equal to 1 and less than 30).
 				// If the TimeoutSeconds value is set to nil and the cluster version is 1.13.*, users are
@@ -71,10 +71,10 @@ func (w *webhookTimeoutCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, e
 		}
 	}
 
-	for i := range objects.MutatingWebhookConfigurations.Items {
-		config := objects.MutatingWebhookConfigurations.Items[i]
-		for k := range config.Webhooks {
-			wh := config.Webhooks[k]
+	for _, config := range objects.MutatingWebhookConfigurations.Items {
+		config := config
+		for _, wh := range config.Webhooks {
+			wh := wh
 			if wh.TimeoutSeconds == nil {
 				// TimeoutSeconds value should be set to a non-nil value (greater than or equal to 1 and less than 30).
 				// If the TimeoutSeconds value is set to nil and the cluster version is 1.13.*, users are

--- a/checks/doks/admission_controller_webhook_timeout.go
+++ b/checks/doks/admission_controller_webhook_timeout.go
@@ -47,8 +47,10 @@ func (w *webhookTimeoutCheck) Description() string {
 func (w *webhookTimeoutCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
 	var diagnostics []checks.Diagnostic
 
-	for _, config := range objects.ValidatingWebhookConfigurations.Items {
-		for _, wh := range config.Webhooks {
+	for i := range objects.ValidatingWebhookConfigurations.Items {
+		config := objects.ValidatingWebhookConfigurations.Items[i]
+		for k := range config.Webhooks {
+			wh := config.Webhooks[k]
 			if wh.TimeoutSeconds == nil {
 				// TimeoutSeconds value should be set to a non-nil value (greater than or equal to 1 and less than 30).
 				// If the TimeoutSeconds value is set to nil and the cluster version is 1.13.*, users are
@@ -69,8 +71,10 @@ func (w *webhookTimeoutCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, e
 		}
 	}
 
-	for _, config := range objects.MutatingWebhookConfigurations.Items {
-		for _, wh := range config.Webhooks {
+	for i := range objects.MutatingWebhookConfigurations.Items {
+		config := objects.MutatingWebhookConfigurations.Items[i]
+		for k := range config.Webhooks {
+			wh := config.Webhooks[k]
 			if wh.TimeoutSeconds == nil {
 				// TimeoutSeconds value should be set to a non-nil value (greater than or equal to 1 and less than 30).
 				// If the TimeoutSeconds value is set to nil and the cluster version is 1.13.*, users are


### PR DESCRIPTION
The admission controller checks for the DOKS suite were returning errors for webhook configurations that were indeed correct. You can reproduce it with a cluster w/ multiple namespaces and admission webhook configs.

Turns out, it was reporting the wrong kube object metadata due to using a reference to a range loop value, which will produce weird references past the loop iteration's lifetime (in this case, it returned object data from *other* webhooks).

This fix clones the data before interacting with it in each loop block.