### PR TITLE
Make "details" for the label check stable

### DIFF
--- a/checks/doks/node_labels_taints.go
+++ b/checks/doks/node_labels_taints.go
@@ -18,6 +18,7 @@ package doks
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/digitalocean/clusterlint/checks"
@@ -57,6 +58,9 @@ func (c *nodeLabelsTaintsCheck) Run(objects *kube.Objects) ([]checks.Diagnostic,
 			}
 		}
 		if len(customLabels) > 0 {
+			// The order of the map iteration above is non-deterministic, so
+			// sort the labels for stable output.
+			sort.Strings(customLabels)
 			d := checks.Diagnostic{
 				Severity: checks.Warning,
 				Message:  "Custom node labels will be lost if node is replaced or upgraded. Add custom labels on node pools instead.",

--- a/checks/doks/node_labels_taints_test.go
+++ b/checks/doks/node_labels_taints_test.go
@@ -77,7 +77,7 @@ func TestNodeLabels(t *testing.T) {
 				Severity: checks.Warning,
 				Message:  "Custom node labels will be lost if node is replaced or upgraded. Add custom labels on node pools instead.",
 				Kind:     checks.Node,
-				Details:  "Custom node labels: [example.com/custom-label example.com/another-label]",
+				Details:  "Custom node labels: [example.com/another-label example.com/custom-label]",
 				Object: &metav1.ObjectMeta{
 					Labels: map[string]string{
 						"doks.digitalocean.com/foo":                "bar",


### PR DESCRIPTION
The tests for #90 failed because the order of map iteration is non-deterministic, causing custom labels in the node label check to appear in random order in the diagnostic details. Sort the slice of labels so that the output is stable.