### PR TITLE
Check env vars for secret key references

### DIFF
--- a/checks/basic/unused_secrets.go
+++ b/checks/basic/unused_secrets.go
@@ -126,13 +126,18 @@ func checkReferences(objects *kube.Objects) (map[kube.Identifier]struct{}, error
 	return used, g.Wait()
 }
 
-// envVarsSecretRefs checks for config map references in container environment variables
+// envVarsSecretRefs checks for secret references in container environment variables
 func envVarsSecretRefs(containers []corev1.Container, namespace string) []kube.Identifier {
 	var refs []kube.Identifier
 	for _, container := range containers {
 		for _, env := range container.EnvFrom {
 			if env.SecretRef != nil {
 				refs = append(refs, kube.Identifier{Name: env.SecretRef.LocalObjectReference.Name, Namespace: namespace})
+			}
+		}
+		for _, env := range container.Env {
+			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+				refs = append(refs, kube.Identifier{Name: env.ValueFrom.SecretKeyRef.LocalObjectReference.Name, Namespace: namespace})
 			}
 		}
 	}

--- a/checks/basic/unused_secrets.go
+++ b/checks/basic/unused_secrets.go
@@ -112,7 +112,7 @@ func checkReferences(objects *kube.Objects) (map[kube.Identifier]struct{}, error
 				mu.Unlock()
 			}
 			identifiers := envVarsSecretRefs(pod.Spec.Containers, namespace)
-			identifiers = append(identifiers, checkEnvVars(pod.Spec.InitContainers, namespace)...)
+			identifiers = append(identifiers, envVarsSecretRefs(pod.Spec.InitContainers, namespace)...)
 			mu.Lock()
 			for _, i := range identifiers {
 				used[i] = empty

--- a/checks/basic/unused_secrets_test.go
+++ b/checks/basic/unused_secrets_test.go
@@ -64,6 +64,11 @@ func TestUnusedSecretWarning(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name:     "environment variable value from references secret",
+			objs:     secretEnvVarValueFromSource(),
+			expected: nil,
+		},
+		{
 			name:     "pod with image pull secrets",
 			objs:     imagePullSecrets(),
 			expected: nil,
@@ -174,6 +179,29 @@ func secretEnvSource() *kube.Objects {
 					},
 				},
 			}},
+	}
+	return objs
+}
+
+func secretEnvVarValueFromSource() *kube.Objects {
+	objs := initSecret()
+	objs.Pods.Items[0].Spec = corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "test-container",
+				Image: "docker.io/nginx",
+				Env: []corev1.EnvVar{
+					{
+						Name: "special_env_var",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "secret_foo"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	return objs
 }

--- a/checks/basic/unused_secrets_test.go
+++ b/checks/basic/unused_secrets_test.go
@@ -69,6 +69,16 @@ func TestUnusedSecretWarning(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name:     "init container environment variable references secret",
+			objs:     initContainerSecretEnvSource(),
+			expected: nil,
+		},
+		{
+			name:     "init container environment variable value from references secret",
+			objs:     initContainerSecretEnvVarValueFromSource(),
+			expected: nil,
+		},
+		{
 			name:     "pod with image pull secrets",
 			objs:     imagePullSecrets(),
 			expected: nil,
@@ -183,10 +193,52 @@ func secretEnvSource() *kube.Objects {
 	return objs
 }
 
+func initContainerSecretEnvSource() *kube.Objects {
+	objs := initSecret()
+	objs.Pods.Items[0].Spec = corev1.PodSpec{
+		InitContainers: []corev1.Container{
+			{
+				Name:  "test-container",
+				Image: "docker.io/nginx",
+				EnvFrom: []corev1.EnvFromSource{
+					{
+						SecretRef: &corev1.SecretEnvSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "secret_foo"},
+						},
+					},
+				},
+			}},
+	}
+	return objs
+}
+
 func secretEnvVarValueFromSource() *kube.Objects {
 	objs := initSecret()
 	objs.Pods.Items[0].Spec = corev1.PodSpec{
 		Containers: []corev1.Container{
+			{
+				Name:  "test-container",
+				Image: "docker.io/nginx",
+				Env: []corev1.EnvVar{
+					{
+						Name: "special_env_var",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "secret_foo"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return objs
+}
+
+func initContainerSecretEnvVarValueFromSource() *kube.Objects {
+	objs := initSecret()
+	objs.Pods.Items[0].Spec = corev1.PodSpec{
+		InitContainers: []corev1.Container{
 			{
 				Name:  "test-container",
 				Image: "docker.io/nginx",


### PR DESCRIPTION
Clusterlint has a bug where secrets that are referenced only by a secretKeyRef are listed as unused.

```yaml
    spec:
      containers:
          env:
            - name: APP_ENV_VAR_NAME
              valueFrom:
                secretKeyRef:
                  key: SECRET_KEY_NAME
                  name: secret-shown-as-unused
```

This bug isn't present for config maps so I have added a test based on the equivalent config map test and extended the function that finds which secrets are used to also identify secrets based on secretKeyRefs.