### PR TITLE
Allow images on docker.io without 'library'

### DIFF
--- a/checks/basic/fully_qualified_image.go
+++ b/checks/basic/fully_qualified_image.go
@@ -18,6 +18,7 @@ package basic
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/digitalocean/clusterlint/checks"
 	"github.com/digitalocean/clusterlint/kube"
@@ -79,7 +80,7 @@ func (fq *fullyQualifiedImageCheck) checkImage(containers []corev1.Container, po
 			}
 			diagnostics = append(diagnostics, d)
 		} else {
-			if value.String() != container.Image {
+			if !equalImageReferences(value.String(), container.Image) {
 				d := checks.Diagnostic{
 					Severity: checks.Warning,
 					Message:  fmt.Sprintf("Use fully qualified image for container '%s'", container.Name),
@@ -92,4 +93,14 @@ func (fq *fullyQualifiedImageCheck) checkImage(containers []corev1.Container, po
 		}
 	}
 	return diagnostics
+}
+
+func equalImageReferences(normalised, image string) bool {
+	if normalised == image {
+		return true
+	}
+	if strings.Replace(normalised, "docker.io/library/", "docker.io/", 1) == image {
+		return true
+	}
+	return false
 }

--- a/checks/basic/fully_qualified_image_test.go
+++ b/checks/basic/fully_qualified_image_test.go
@@ -59,6 +59,11 @@ func TestFullyQualifiedImageWarning(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name:     "pod with container image - docker.io/busybox:latest",
+			objs:     container("docker.io/busybox:1.2.3"),
+			expected: nil,
+		},
+		{
 			name:     "pod with container image - busybox:latest",
 			objs:     container("busybox:latest"),
 			expected: issues(severity, message, checks.Pod, name),


### PR DESCRIPTION
For the check `fully-qualified-image` the function `reference.ParseAnyReference` is used to discover how docker will interpret a container image reference, for images on docker hub that are official images it results in a reference like `docker.io/library/busybox:1.2.3` but another valid fully qualified reference would be `docker.io/busybox:1.2.3`.

This change adds a test to check that `docker.io/busybox:1.2.3` gives no warnings and adds a function for comparing image references that takes the optional nature of "library" into account.