### PR TITLE
Support both v1beta1 and v1 admission control webhooks

### DIFF
--- a/checks/basic/admission_controller_webhook_v1beta1.go
+++ b/checks/basic/admission_controller_webhook_v1beta1.go
@@ -47,6 +47,14 @@ func (w *betaWebhookCheck) Description() string {
 
 // Run runs this check on a set of Kubernetes objects.
 func (w *betaWebhookCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
+	if len(objects.ValidatingWebhookConfigurations.Items) > 0 ||
+		len(objects.MutatingWebhookConfigurations.Items) > 0 {
+		// Skip this check if there are v1 webhook configurations. On clusters
+		// that support both v1beta1 and v1 admission control, the same webhook
+		// configurations will be returned for both versions.
+		return nil, nil
+	}
+
 	const apiserverServiceName = "kubernetes"
 
 	var diagnostics []checks.Diagnostic

--- a/checks/basic/admission_controller_webhook_v1beta1.go
+++ b/checks/basic/admission_controller_webhook_v1beta1.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"fmt"
+
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+)
+
+func init() {
+	checks.Register(&betaWebhookCheck{})
+}
+
+type betaWebhookCheck struct{}
+
+// Name returns a unique name for this check.
+func (w *betaWebhookCheck) Name() string {
+	return "admission-controller-webhook-v1beta1"
+}
+
+// Groups returns a list of group names this check should be part of.
+func (w *betaWebhookCheck) Groups() []string {
+	return []string{"basic"}
+}
+
+// Description returns a detailed human-readable description of what this check
+// does.
+func (w *betaWebhookCheck) Description() string {
+	return "Check for admission control webhooks"
+}
+
+// Run runs this check on a set of Kubernetes objects.
+func (w *betaWebhookCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
+	const apiserverServiceName = "kubernetes"
+
+	var diagnostics []checks.Diagnostic
+
+	for _, config := range objects.ValidatingWebhookConfigurationsBeta.Items {
+		for _, wh := range config.Webhooks {
+			if wh.ClientConfig.Service != nil {
+				// Ensure that the service (and its namespace) that is configure actually exists.
+
+				if !namespaceExists(objects.Namespaces, wh.ClientConfig.Service.Namespace) {
+					diagnostics = append(diagnostics, checks.Diagnostic{
+						Severity: checks.Error,
+						Message:  fmt.Sprintf("Validating webhook %s is configured against a service in a namespace that does not exist.", wh.Name),
+						Kind:     checks.ValidatingWebhookConfiguration,
+						Object:   &config.ObjectMeta,
+						Owners:   config.ObjectMeta.GetOwnerReferences(),
+					})
+					continue
+				}
+
+				if !serviceExists(objects.Services, wh.ClientConfig.Service.Name, wh.ClientConfig.Service.Namespace) {
+					diagnostics = append(diagnostics, checks.Diagnostic{
+						Severity: checks.Error,
+						Message:  fmt.Sprintf("Validating webhook %s is configured against a service that does not exist.", wh.Name),
+						Kind:     checks.ValidatingWebhookConfiguration,
+						Object:   &config.ObjectMeta,
+						Owners:   config.ObjectMeta.GetOwnerReferences(),
+					})
+				}
+			}
+		}
+	}
+
+	for _, config := range objects.MutatingWebhookConfigurationsBeta.Items {
+		for _, wh := range config.Webhooks {
+			if wh.ClientConfig.Service != nil {
+				// Ensure that the service (and its namespace) that is configure actually exists.
+
+				if !namespaceExists(objects.Namespaces, wh.ClientConfig.Service.Namespace) {
+					diagnostics = append(diagnostics, checks.Diagnostic{
+						Severity: checks.Error,
+						Message:  fmt.Sprintf("Mutating webhook %s is configured against a service in a namespace that does not exist.", wh.Name),
+						Kind:     checks.MutatingWebhookConfiguration,
+						Object:   &config.ObjectMeta,
+						Owners:   config.ObjectMeta.GetOwnerReferences(),
+					})
+					continue
+				}
+
+				if !serviceExists(objects.Services, wh.ClientConfig.Service.Name, wh.ClientConfig.Service.Namespace) {
+					diagnostics = append(diagnostics, checks.Diagnostic{
+						Severity: checks.Error,
+						Message:  fmt.Sprintf("Mutating webhook %s is configured against a service that does not exist.", wh.Name),
+						Kind:     checks.MutatingWebhookConfiguration,
+						Object:   &config.ObjectMeta,
+						Owners:   config.ObjectMeta.GetOwnerReferences(),
+					})
+				}
+			}
+		}
+	}
+	return diagnostics, nil
+}

--- a/checks/basic/admission_controller_webhook_v1beta1_test.go
+++ b/checks/basic/admission_controller_webhook_v1beta1_test.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"testing"
+
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+	"github.com/stretchr/testify/assert"
+	ar "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBetaWebhookCheckMeta(t *testing.T) {
+	betaWebhookCheck := betaWebhookCheck{}
+	assert.Equal(t, "admission-controller-webhook-v1beta1", betaWebhookCheck.Name())
+	assert.Equal(t, []string{"basic"}, betaWebhookCheck.Groups())
+	assert.NotEmpty(t, betaWebhookCheck.Description())
+}
+
+func TestBetaWebhookCheckRegistration(t *testing.T) {
+	betaWebhookCheck := &betaWebhookCheck{}
+	check, err := checks.Get("admission-controller-webhook-v1beta1")
+	assert.NoError(t, err)
+	assert.Equal(t, check, betaWebhookCheck)
+}
+
+func TestBetaWebHookRun(t *testing.T) {
+	emptyNamespaceList := &corev1.NamespaceList{
+		Items: []corev1.Namespace{},
+	}
+	emptyServiceList := &corev1.ServiceList{
+		Items: []corev1.Service{},
+	}
+
+	baseMWC := ar.MutatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{Kind: "MutatingWebhookConfiguration", APIVersion: "v1beta1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mwc_foo",
+		},
+		Webhooks: []ar.MutatingWebhook{},
+	}
+	baseMW := ar.MutatingWebhook{
+		Name: "mw_foo",
+	}
+
+	baseVWC := ar.ValidatingWebhookConfiguration{
+		TypeMeta: metav1.TypeMeta{Kind: "ValidatingWebhookConfiguration", APIVersion: "v1beta1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vwc_foo",
+		},
+		Webhooks: []ar.ValidatingWebhook{},
+	}
+	baseVW := ar.ValidatingWebhook{
+		Name: "vw_foo",
+	}
+
+	tests := []struct {
+		name     string
+		objs     *kube.Objects
+		expected []checks.Diagnostic
+	}{
+		{
+			name: "no webhook configuration",
+			objs: &kube.Objects{
+				MutatingWebhookConfigurationsBeta:   &ar.MutatingWebhookConfigurationList{},
+				ValidatingWebhookConfigurationsBeta: &ar.ValidatingWebhookConfigurationList{},
+				SystemNamespace:                     &corev1.Namespace{},
+			},
+			expected: nil,
+		},
+		{
+			name: "direct url webhooks",
+			objs: &kube.Objects{
+				Namespaces: emptyNamespaceList,
+				MutatingWebhookConfigurationsBeta: &ar.MutatingWebhookConfigurationList{
+					Items: []ar.MutatingWebhookConfiguration{
+						func() ar.MutatingWebhookConfiguration {
+							mwc := baseMWC
+							mw := baseMW
+							mw.ClientConfig = ar.WebhookClientConfig{
+								URL: strPtr("http://webhook.com"),
+							}
+							mwc.Webhooks = append(mwc.Webhooks, mw)
+							return mwc
+						}(),
+					},
+				},
+				ValidatingWebhookConfigurationsBeta: &ar.ValidatingWebhookConfigurationList{
+					Items: []ar.ValidatingWebhookConfiguration{
+						func() ar.ValidatingWebhookConfiguration {
+							vwc := baseVWC
+							vw := baseVW
+							vw.ClientConfig = ar.WebhookClientConfig{
+								URL: strPtr("http://webhook.com"),
+							}
+							vwc.Webhooks = append(vwc.Webhooks, vw)
+							return vwc
+						}(),
+					},
+				},
+				SystemNamespace: &corev1.Namespace{},
+			},
+			expected: nil,
+		},
+		{
+			name: "namespace does not exist",
+			objs: &kube.Objects{
+				Namespaces: emptyNamespaceList,
+				Services: &corev1.ServiceList{
+					Items: []corev1.Service{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "service",
+							},
+						},
+					},
+				},
+				MutatingWebhookConfigurationsBeta: &ar.MutatingWebhookConfigurationList{
+					Items: []ar.MutatingWebhookConfiguration{
+						func() ar.MutatingWebhookConfiguration {
+							mwc := baseMWC
+							mw := baseMW
+							mw.ClientConfig = ar.WebhookClientConfig{
+								Service: &ar.ServiceReference{
+									Namespace: "missing",
+									Name:      "service",
+								},
+							}
+							mwc.Webhooks = append(mwc.Webhooks, mw)
+							return mwc
+						}(),
+					},
+				},
+				ValidatingWebhookConfigurationsBeta: &ar.ValidatingWebhookConfigurationList{
+					Items: []ar.ValidatingWebhookConfiguration{
+						func() ar.ValidatingWebhookConfiguration {
+							vwc := baseVWC
+							vw := baseVW
+							vw.ClientConfig = ar.WebhookClientConfig{
+								Service: &ar.ServiceReference{
+									Namespace: "missing",
+									Name:      "service",
+								},
+							}
+							vwc.Webhooks = append(vwc.Webhooks, vw)
+							return vwc
+						}(),
+					},
+				},
+				SystemNamespace: &corev1.Namespace{},
+			},
+			expected: []checks.Diagnostic{
+				{
+					Severity: checks.Error,
+					Message:  "Validating webhook vw_foo is configured against a service in a namespace that does not exist.",
+					Kind:     checks.ValidatingWebhookConfiguration,
+				},
+				{
+					Severity: checks.Error,
+					Message:  "Mutating webhook mw_foo is configured against a service in a namespace that does not exist.",
+					Kind:     checks.MutatingWebhookConfiguration,
+				},
+			},
+		},
+		{
+			name: "service does not exist",
+			objs: &kube.Objects{
+				Namespaces: &corev1.NamespaceList{
+					Items: []corev1.Namespace{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "webhook",
+							},
+						},
+					},
+				},
+				Services: emptyServiceList,
+				MutatingWebhookConfigurationsBeta: &ar.MutatingWebhookConfigurationList{
+					Items: []ar.MutatingWebhookConfiguration{
+						func() ar.MutatingWebhookConfiguration {
+							mwc := baseMWC
+							mw := baseMW
+							mw.ClientConfig = ar.WebhookClientConfig{
+								Service: &ar.ServiceReference{
+									Namespace: "webhook",
+									Name:      "service",
+								},
+							}
+							mwc.Webhooks = append(mwc.Webhooks, mw)
+							return mwc
+						}(),
+					},
+				},
+				ValidatingWebhookConfigurationsBeta: &ar.ValidatingWebhookConfigurationList{
+					Items: []ar.ValidatingWebhookConfiguration{
+						func() ar.ValidatingWebhookConfiguration {
+							vwc := baseVWC
+							vw := baseVW
+							vw.ClientConfig = ar.WebhookClientConfig{
+								Service: &ar.ServiceReference{
+									Namespace: "webhook",
+									Name:      "service",
+								},
+							}
+							vwc.Webhooks = append(vwc.Webhooks, vw)
+							return vwc
+						}(),
+					},
+				},
+				SystemNamespace: &corev1.Namespace{},
+			},
+			expected: []checks.Diagnostic{
+				{
+					Severity: checks.Error,
+					Message:  "Validating webhook vw_foo is configured against a service that does not exist.",
+					Kind:     checks.ValidatingWebhookConfiguration,
+				},
+				{
+					Severity: checks.Error,
+					Message:  "Mutating webhook mw_foo is configured against a service that does not exist.",
+					Kind:     checks.MutatingWebhookConfiguration,
+				},
+			},
+		},
+	}
+
+	betaWebhookCheck := betaWebhookCheck{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diagnostics, err := betaWebhookCheck.Run(test.objs)
+			assert.NoError(t, err)
+
+			// skip checking object and owner since for this checker it just uses the object being checked.
+			var strippedDiagnostics []checks.Diagnostic
+			for _, d := range diagnostics {
+				d.Object = nil
+				d.Owners = nil
+				strippedDiagnostics = append(strippedDiagnostics, d)
+			}
+
+			assert.ElementsMatch(t, test.expected, strippedDiagnostics)
+		})
+	}
+}

--- a/checks/doks/admission_controller_webhook_replacement_v1beta1.go
+++ b/checks/doks/admission_controller_webhook_replacement_v1beta1.go
@@ -48,6 +48,14 @@ func (w *betaWebhookReplacementCheck) Description() string {
 
 // Run runs this check on a set of Kubernetes objects.
 func (w *betaWebhookReplacementCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
+	if len(objects.ValidatingWebhookConfigurations.Items) > 0 ||
+		len(objects.MutatingWebhookConfigurations.Items) > 0 {
+		// Skip this check if there are v1 webhook configurations. On clusters
+		// that support both v1beta1 and v1 admission control, the same webhook
+		// configurations will be returned for both versions.
+		return nil, nil
+	}
+
 	const apiserverServiceName = "kubernetes"
 
 	var diagnostics []checks.Diagnostic

--- a/checks/doks/admission_controller_webhook_replacement_v1beta1.go
+++ b/checks/doks/admission_controller_webhook_replacement_v1beta1.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package doks
+
+import (
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+	ar "k8s.io/api/admissionregistration/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func init() {
+	checks.Register(&betaWebhookReplacementCheck{})
+}
+
+type betaWebhookReplacementCheck struct{}
+
+// Name returns a unique name for this check.
+func (w *betaWebhookReplacementCheck) Name() string {
+	return "admission-controller-webhook-replacement-v1beta1"
+}
+
+// Groups returns a list of group names this check should be part of.
+func (w *betaWebhookReplacementCheck) Groups() []string {
+	return []string{"doks"}
+}
+
+// Description returns a detailed human-readable description of what this check
+// does.
+func (w *betaWebhookReplacementCheck) Description() string {
+	return "Check for admission control webhooks that could cause problems during upgrades or node replacement"
+}
+
+// Run runs this check on a set of Kubernetes objects.
+func (w *betaWebhookReplacementCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
+	const apiserverServiceName = "kubernetes"
+
+	var diagnostics []checks.Diagnostic
+
+	for _, config := range objects.ValidatingWebhookConfigurationsBeta.Items {
+		config := config
+		for _, wh := range config.Webhooks {
+			wh := wh
+			if !applicableBeta(wh.Rules) {
+				// Webhooks that do not apply to core/v1, apps/v1, apps/v1beta1, apps/v1beta2 resources are fine
+				continue
+			}
+			if *wh.FailurePolicy == ar.Ignore {
+				// Webhooks with failurePolicy: Ignore are fine.
+				continue
+			}
+			if wh.ClientConfig.Service == nil {
+				// Webhooks whose targets are external to the cluster are fine.
+				continue
+			}
+			if wh.ClientConfig.Service.Namespace == metav1.NamespaceDefault &&
+				wh.ClientConfig.Service.Name == apiserverServiceName {
+				// Webhooks that target the kube-apiserver are fine.
+				continue
+			}
+			if !selectorMatchesNamespace(wh.NamespaceSelector, objects.SystemNamespace) {
+				// Webhooks that don't apply to kube-system are fine.
+				continue
+			}
+			var svcNamespace *v1.Namespace
+			for _, ns := range objects.Namespaces.Items {
+				ns := ns
+				if ns.Name == wh.ClientConfig.Service.Namespace {
+					svcNamespace = &ns
+				}
+			}
+			if svcNamespace != nil &&
+				!selectorMatchesNamespace(wh.NamespaceSelector, svcNamespace) &&
+				len(objects.Nodes.Items) > 1 {
+				// Webhooks that don't apply to their own namespace are fine, as
+				// long as there's more than one node in the cluster.
+				continue
+			}
+
+			d := checks.Diagnostic{
+				Severity: checks.Error,
+				Message:  "Validating webhook is configured in such a way that it may be problematic during upgrades.",
+				Kind:     checks.ValidatingWebhookConfiguration,
+				Object:   &config.ObjectMeta,
+				Owners:   config.ObjectMeta.GetOwnerReferences(),
+			}
+			diagnostics = append(diagnostics, d)
+
+			// We don't want to produce diagnostics for multiple webhooks in the
+			// same webhook configuration, so break out of the inner loop if we
+			// get here.
+			break
+		}
+	}
+
+	for _, config := range objects.MutatingWebhookConfigurationsBeta.Items {
+		config := config
+		for _, wh := range config.Webhooks {
+			wh := wh
+			if !applicableBeta(wh.Rules) {
+				// Webhooks that do not apply to core/v1, apps/v1, apps/v1beta1, apps/v1beta2 resources are fine
+				continue
+			}
+			if *wh.FailurePolicy == ar.Ignore {
+				// Webhooks with failurePolicy: Ignore are fine.
+				continue
+			}
+			if wh.ClientConfig.Service == nil {
+				// Webhooks whose targets are external to the cluster are fine.
+				continue
+			}
+			if wh.ClientConfig.Service.Namespace == metav1.NamespaceDefault &&
+				wh.ClientConfig.Service.Name == apiserverServiceName {
+				// Webhooks that target the kube-apiserver are fine.
+				continue
+			}
+			if !selectorMatchesNamespace(wh.NamespaceSelector, objects.SystemNamespace) {
+				// Webhooks that don't apply to kube-system are fine.
+				continue
+			}
+			var svcNamespace *v1.Namespace
+			for _, ns := range objects.Namespaces.Items {
+				ns := ns
+				if ns.Name == wh.ClientConfig.Service.Namespace {
+					svcNamespace = &ns
+				}
+			}
+			if svcNamespace != nil &&
+				!selectorMatchesNamespace(wh.NamespaceSelector, svcNamespace) &&
+				len(objects.Nodes.Items) > 1 {
+				// Webhooks that don't apply to their own namespace are fine, as
+				// long as there's more than one node in the cluster.
+				continue
+			}
+
+			d := checks.Diagnostic{
+				Severity: checks.Error,
+				Message:  "Mutating webhook is configured in such a way that it may be problematic during upgrades.",
+				Kind:     checks.MutatingWebhookConfiguration,
+				Object:   &config.ObjectMeta,
+				Owners:   config.ObjectMeta.GetOwnerReferences(),
+			}
+			diagnostics = append(diagnostics, d)
+
+			// We don't want to produce diagnostics for multiple webhooks in the
+			// same webhook configuration, so break out of the inner loop if we
+			// get here.
+			break
+		}
+	}
+	return diagnostics, nil
+}
+
+func applicableBeta(rules []ar.RuleWithOperations) bool {
+	for _, r := range rules {
+		if apiVersions(r.APIVersions) {
+			// applies to "apiVersions: v1"
+			if len(r.APIGroups) == 0 {
+				return true
+			}
+			// applies to "apiVersion: v1", "apiVersion: apps/v1", "apiVersion: apps/v1beta1", "apiVersion: apps/v1beta2"
+			for _, g := range r.APIGroups {
+				if g == "" || g == "*" || g == "apps" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/checks/doks/admission_controller_webhook_replacement_v1beta1_test.go
+++ b/checks/doks/admission_controller_webhook_replacement_v1beta1_test.go
@@ -1,0 +1,489 @@
+/*
+Copyright 2019 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package doks
+
+import (
+	"testing"
+
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+	"github.com/stretchr/testify/assert"
+	ar "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBetaWebhookCheckMeta(t *testing.T) {
+	webhookCheck := betaWebhookReplacementCheck{}
+	assert.Equal(t, "admission-controller-webhook-replacement-v1beta1", webhookCheck.Name())
+	assert.Equal(t, []string{"doks"}, webhookCheck.Groups())
+	assert.NotEmpty(t, webhookCheck.Description())
+}
+
+func TestBetaWebhookCheckRegistration(t *testing.T) {
+	webhookCheck := &betaWebhookReplacementCheck{}
+	check, err := checks.Get("admission-controller-webhook-replacement-v1beta1")
+	assert.NoError(t, err)
+	assert.Equal(t, check, webhookCheck)
+}
+
+func TestBetaWebhookError(t *testing.T) {
+	tests := []struct {
+		name     string
+		objs     *kube.Objects
+		expected []checks.Diagnostic
+	}{
+		{
+			name: "no webhook configurations",
+			objs: &kube.Objects{
+				MutatingWebhookConfigurationsBeta:   &ar.MutatingWebhookConfigurationList{},
+				ValidatingWebhookConfigurationsBeta: &ar.ValidatingWebhookConfigurationList{},
+				SystemNamespace:                     &corev1.Namespace{},
+			},
+			expected: nil,
+		},
+		{
+			name: "failure policy is ignore",
+			objs: webhookTestObjectsBeta(
+				ar.Ignore,
+				&metav1.LabelSelector{},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: nil,
+		},
+		{
+			name: "webook does not use service",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{},
+				ar.WebhookClientConfig{
+					URL: &webhookURL,
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: nil,
+		},
+		{
+			name: "webook service is apiserver",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "default",
+						Name:      "kubernetes",
+					},
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: nil,
+		},
+		{
+			name: "namespace label selector does not match kube-system",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{
+					MatchLabels: map[string]string{"non-existent-label-on-namespace": "bar"},
+				},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: nil,
+		},
+		{
+			name: "namespace OpExists expression selector does not match kube-system",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{
+					MatchExpressions: expr("non-existent", []string{}, metav1.LabelSelectorOpExists),
+				},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: nil,
+		},
+		{
+			name: "namespace OpDoesNotExist expression selector does not match kube-system",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{
+					MatchExpressions: expr("doks_key", []string{}, metav1.LabelSelectorOpDoesNotExist),
+				},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: nil,
+		},
+		{
+			name: "namespace OpIn expression selector does not match kube-system",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{
+					MatchExpressions: expr("doks_key", []string{"non-existent"}, metav1.LabelSelectorOpIn),
+				},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: nil,
+		},
+		{
+			name: "namespace OpNotIn expression selector does not match kube-system",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{
+					MatchExpressions: expr("doks_key", []string{"bar"}, metav1.LabelSelectorOpNotIn),
+				},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: nil,
+		},
+		{
+			name: "namespace label selector does not match own namespace",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{
+					MatchLabels: map[string]string{"doks_key": "bar"},
+				},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: nil,
+		},
+		{
+			name: "single-node cluster",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{
+					MatchLabels: map[string]string{"doks_key": "bar"},
+				},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				1,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: webhookErrorsBeta(),
+		},
+		{
+			name: "webhook applies to its own namespace and kube-system",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: webhookErrorsBeta(),
+		},
+		{
+			name: "error: webhook applies to core/v1 group",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{""},
+				[]string{"v1"},
+			),
+			expected: webhookErrorsBeta(),
+		},
+		{
+			name: "error: webhook applies to apps/v1 group",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"apps"},
+				[]string{"v1"},
+			),
+			expected: webhookErrorsBeta(),
+		},
+		{
+			name: "error: webhook applies to apps/v1beta1 group",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"apps"},
+				[]string{"v1beta1"},
+			),
+			expected: webhookErrorsBeta(),
+		},
+		{
+			name: "error: webhook applies to apps/v1beta2 group",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"apps"},
+				[]string{"v1beta2"},
+			),
+			expected: webhookErrorsBeta(),
+		},
+		{
+			name: "error: webhook applies to *",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"*"},
+				[]string{"*"},
+			),
+			expected: webhookErrorsBeta(),
+		},
+		{
+			name: "no error: webhook applies to batch/v1",
+			objs: webhookTestObjectsBeta(
+				ar.Fail,
+				&metav1.LabelSelector{},
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				2,
+				[]string{"batch"},
+				[]string{"*"},
+			),
+			expected: nil,
+		},
+	}
+
+	webhookCheck := betaWebhookReplacementCheck{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d, err := webhookCheck.Run(test.objs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, test.expected, d)
+		})
+	}
+}
+
+func webhookTestObjectsBeta(
+	failurePolicyType ar.FailurePolicyType,
+	nsSelector *metav1.LabelSelector,
+	clientConfig ar.WebhookClientConfig,
+	numNodes int,
+	groups []string,
+	versions []string,
+) *kube.Objects {
+	objs := &kube.Objects{
+		SystemNamespace: &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "kube-system",
+				Labels: map[string]string{"doks_key": "bar"},
+			},
+		},
+		Namespaces: &corev1.NamespaceList{
+			Items: []corev1.Namespace{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "kube-system",
+						Labels: map[string]string{"doks_key": "bar"},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "webhook",
+						Labels: map[string]string{"doks_key": "xyzzy"},
+					},
+				},
+			},
+		},
+		MutatingWebhookConfigurationsBeta: &ar.MutatingWebhookConfigurationList{
+			Items: []ar.MutatingWebhookConfiguration{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "MutatingWebhookConfiguration", APIVersion: "v1beta1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mwc_foo",
+					},
+					Webhooks: []ar.MutatingWebhook{
+						{
+							Name:              "mw_foo",
+							FailurePolicy:     &failurePolicyType,
+							NamespaceSelector: nsSelector,
+							ClientConfig:      clientConfig,
+							Rules: []ar.RuleWithOperations{
+								{
+									Rule: ar.Rule{
+										APIGroups:   groups,
+										APIVersions: versions,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ValidatingWebhookConfigurationsBeta: &ar.ValidatingWebhookConfigurationList{
+			Items: []ar.ValidatingWebhookConfiguration{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "ValidatingWebhookConfiguration", APIVersion: "v1beta1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vwc_foo",
+					},
+					Webhooks: []ar.ValidatingWebhook{
+						{
+							Name:              "vw_foo",
+							FailurePolicy:     &failurePolicyType,
+							NamespaceSelector: nsSelector,
+							ClientConfig:      clientConfig,
+							Rules: []ar.RuleWithOperations{
+								{
+									Rule: ar.Rule{
+										APIGroups:   groups,
+										APIVersions: versions,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	objs.Nodes = &corev1.NodeList{}
+	for i := 0; i < numNodes; i++ {
+		objs.Nodes.Items = append(objs.Nodes.Items, corev1.Node{})
+	}
+	return objs
+}
+
+func webhookErrorsBeta() []checks.Diagnostic {
+	objs := webhookTestObjectsBeta(ar.Fail, nil, ar.WebhookClientConfig{}, 0, []string{"*"}, []string{"*"})
+	validatingConfig := objs.ValidatingWebhookConfigurationsBeta.Items[0]
+	mutatingConfig := objs.MutatingWebhookConfigurationsBeta.Items[0]
+
+	diagnostics := []checks.Diagnostic{
+		{
+			Severity: checks.Error,
+			Message:  "Validating webhook is configured in such a way that it may be problematic during upgrades.",
+			Kind:     checks.ValidatingWebhookConfiguration,
+			Object:   &validatingConfig.ObjectMeta,
+			Owners:   validatingConfig.ObjectMeta.GetOwnerReferences(),
+		},
+		{
+			Severity: checks.Error,
+			Message:  "Mutating webhook is configured in such a way that it may be problematic during upgrades.",
+			Kind:     checks.MutatingWebhookConfiguration,
+			Object:   &mutatingConfig.ObjectMeta,
+			Owners:   mutatingConfig.ObjectMeta.GetOwnerReferences(),
+		},
+	}
+	return diagnostics
+}

--- a/checks/doks/admission_controller_webhook_timeout_v1beta1.go
+++ b/checks/doks/admission_controller_webhook_timeout_v1beta1.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package doks
+
+import (
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+)
+
+func init() {
+	checks.Register(&betaWebhookTimeoutCheck{})
+}
+
+type betaWebhookTimeoutCheck struct{}
+
+// Name returns a unique name for this check.
+func (w *betaWebhookTimeoutCheck) Name() string {
+	return "admission-controller-webhook-timeout-v1beta1"
+}
+
+// Groups returns a list of group names this check should be part of.
+func (w *betaWebhookTimeoutCheck) Groups() []string {
+	return []string{"doks"}
+}
+
+// Description returns a detailed human-readable description of what this check
+// does.
+func (w *betaWebhookTimeoutCheck) Description() string {
+	return "Check for admission control webhooks that have exceeded a timeout of 30 seconds."
+}
+
+// Run runs this check on a set of Kubernetes objects.
+func (w *betaWebhookTimeoutCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
+	var diagnostics []checks.Diagnostic
+
+	for _, config := range objects.ValidatingWebhookConfigurationsBeta.Items {
+		config := config
+		for _, wh := range config.Webhooks {
+			wh := wh
+			if wh.TimeoutSeconds == nil {
+				// TimeoutSeconds value should be set to a non-nil value (greater than or equal to 1 and less than 30).
+				// If the TimeoutSeconds value is set to nil and the cluster version is 1.13.*, users are
+				// unable to configure the TimeoutSeconds value and this value will stay at nil, breaking
+				// upgrades. It's only for versions >= 1.14 that the value will default to 30 seconds.
+				continue
+			} else if *wh.TimeoutSeconds < int32(1) || *wh.TimeoutSeconds >= int32(30) {
+				// Webhooks with TimeoutSeconds set: less than 1 or greater than or equal to 30 is bad.
+				d := checks.Diagnostic{
+					Severity: checks.Error,
+					Message:  "Validating webhook with a TimeoutSeconds value greater than 29 seconds will block upgrades.",
+					Kind:     checks.ValidatingWebhookConfiguration,
+					Object:   &config.ObjectMeta,
+					Owners:   config.ObjectMeta.GetOwnerReferences(),
+				}
+				diagnostics = append(diagnostics, d)
+			}
+		}
+	}
+
+	for _, config := range objects.MutatingWebhookConfigurationsBeta.Items {
+		config := config
+		for _, wh := range config.Webhooks {
+			wh := wh
+			if wh.TimeoutSeconds == nil {
+				// TimeoutSeconds value should be set to a non-nil value (greater than or equal to 1 and less than 30).
+				// If the TimeoutSeconds value is set to nil and the cluster version is 1.13.*, users are
+				// unable to configure the TimeoutSeconds value and this value will stay at nil, breaking
+				// upgrades. It's only for versions >= 1.14 that the value will default to 30 seconds.
+				continue
+			} else if *wh.TimeoutSeconds < int32(1) || *wh.TimeoutSeconds >= int32(30) {
+				// Webhooks with TimeoutSeconds set: less than 1 or greater than or equal to 30 is bad.
+				d := checks.Diagnostic{
+					Severity: checks.Error,
+					Message:  "Mutating webhook with a TimeoutSeconds value greater than 29 seconds will block upgrades.",
+					Kind:     checks.MutatingWebhookConfiguration,
+					Object:   &config.ObjectMeta,
+					Owners:   config.ObjectMeta.GetOwnerReferences(),
+				}
+				diagnostics = append(diagnostics, d)
+			}
+		}
+	}
+	return diagnostics, nil
+}

--- a/checks/doks/admission_controller_webhook_timeout_v1beta1.go
+++ b/checks/doks/admission_controller_webhook_timeout_v1beta1.go
@@ -45,6 +45,14 @@ func (w *betaWebhookTimeoutCheck) Description() string {
 
 // Run runs this check on a set of Kubernetes objects.
 func (w *betaWebhookTimeoutCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
+	if len(objects.ValidatingWebhookConfigurations.Items) > 0 ||
+		len(objects.MutatingWebhookConfigurations.Items) > 0 {
+		// Skip this check if there are v1 webhook configurations. On clusters
+		// that support both v1beta1 and v1 admission control, the same webhook
+		// configurations will be returned for both versions.
+		return nil, nil
+	}
+
 	var diagnostics []checks.Diagnostic
 
 	for _, config := range objects.ValidatingWebhookConfigurationsBeta.Items {

--- a/checks/doks/admission_controller_webhook_timeout_v1beta1_test.go
+++ b/checks/doks/admission_controller_webhook_timeout_v1beta1_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/digitalocean/clusterlint/checks"
 	"github.com/digitalocean/clusterlint/kube"
 	"github.com/stretchr/testify/assert"
+	arv1 "k8s.io/api/admissionregistration/v1"
 	ar "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +42,41 @@ func TestBetaWebhookTimeoutRegistration(t *testing.T) {
 	assert.Equal(t, check, webhookCheck)
 }
 
+func TestBetaWebhookTimeoutSkipWhenV1Exists(t *testing.T) {
+	v1Objs := webhookTimeoutTestObjects(
+		arv1.WebhookClientConfig{
+			Service: &arv1.ServiceReference{
+				Namespace: "webhook",
+				Name:      "webhook-service",
+			},
+		},
+		toIntP(31),
+		2,
+	)
+	betaObjs := webhookTimeoutTestObjectsBeta(
+		ar.WebhookClientConfig{
+			Service: &ar.ServiceReference{
+				Namespace: "webhook",
+				Name:      "webhook-service",
+			},
+		},
+		toIntP(31),
+		2,
+	)
+
+	objs := &kube.Objects{
+		MutatingWebhookConfigurations:       v1Objs.MutatingWebhookConfigurations,
+		ValidatingWebhookConfigurations:     v1Objs.ValidatingWebhookConfigurations,
+		MutatingWebhookConfigurationsBeta:   betaObjs.MutatingWebhookConfigurationsBeta,
+		ValidatingWebhookConfigurationsBeta: betaObjs.ValidatingWebhookConfigurationsBeta,
+	}
+
+	webhookCheck := betaWebhookTimeoutCheck{}
+	d, err := webhookCheck.Run(objs)
+	assert.NoError(t, err)
+	assert.Empty(t, d)
+}
+
 func TestBetaWebhookTimeoutError(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -52,6 +88,8 @@ func TestBetaWebhookTimeoutError(t *testing.T) {
 			objs: &kube.Objects{
 				MutatingWebhookConfigurationsBeta:   &ar.MutatingWebhookConfigurationList{},
 				ValidatingWebhookConfigurationsBeta: &ar.ValidatingWebhookConfigurationList{},
+				MutatingWebhookConfigurations:       &arv1.MutatingWebhookConfigurationList{},
+				ValidatingWebhookConfigurations:     &arv1.ValidatingWebhookConfigurationList{},
 			},
 			expected: nil,
 		},
@@ -169,6 +207,8 @@ func webhookTimeoutTestObjectsBeta(
 				},
 			},
 		},
+		MutatingWebhookConfigurations:   &arv1.MutatingWebhookConfigurationList{},
+		ValidatingWebhookConfigurations: &arv1.ValidatingWebhookConfigurationList{},
 		MutatingWebhookConfigurationsBeta: &ar.MutatingWebhookConfigurationList{
 			Items: []ar.MutatingWebhookConfiguration{
 				{

--- a/checks/doks/admission_controller_webhook_timeout_v1beta1_test.go
+++ b/checks/doks/admission_controller_webhook_timeout_v1beta1_test.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2020 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package doks
+
+import (
+	"testing"
+
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+	"github.com/stretchr/testify/assert"
+	ar "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBetaWebhookTimeoutCheckMeta(t *testing.T) {
+	webhookCheck := betaWebhookTimeoutCheck{}
+	assert.Equal(t, "admission-controller-webhook-timeout-v1beta1", webhookCheck.Name())
+	assert.Equal(t, []string{"doks"}, webhookCheck.Groups())
+	assert.NotEmpty(t, webhookCheck.Description())
+}
+
+func TestBetaWebhookTimeoutRegistration(t *testing.T) {
+	webhookCheck := &betaWebhookTimeoutCheck{}
+	check, err := checks.Get("admission-controller-webhook-timeout-v1beta1")
+	assert.NoError(t, err)
+	assert.Equal(t, check, webhookCheck)
+}
+
+func TestBetaWebhookTimeoutError(t *testing.T) {
+	tests := []struct {
+		name     string
+		objs     *kube.Objects
+		expected []checks.Diagnostic
+	}{
+		{
+			name: "no webhook configurations",
+			objs: &kube.Objects{
+				MutatingWebhookConfigurationsBeta:   &ar.MutatingWebhookConfigurationList{},
+				ValidatingWebhookConfigurationsBeta: &ar.ValidatingWebhookConfigurationList{},
+			},
+			expected: nil,
+		},
+		{
+			name: "TimeoutSeconds value is set to 10 seconds",
+			objs: webhookTimeoutTestObjectsBeta(
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				toIntP(10),
+				2,
+			),
+			expected: nil,
+		},
+		{
+			name: "TimeoutSeconds value is set to 29 seconds",
+			objs: webhookTimeoutTestObjectsBeta(
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				toIntP(29),
+				2,
+			),
+			expected: nil,
+		},
+		{
+			name: "TimeoutSeconds value is set to 30 seconds",
+			objs: webhookTimeoutTestObjectsBeta(
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				toIntP(30),
+				2,
+			),
+			expected: webhookTimeoutErrors(),
+		},
+		{
+			name: "TimeoutSeconds value is set to 31 seconds",
+			objs: webhookTimeoutTestObjectsBeta(
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				toIntP(31),
+				2,
+			),
+			expected: webhookTimeoutErrors(),
+		},
+		{
+			name: "TimeoutSeconds value is set to nil",
+			objs: webhookTimeoutTestObjectsBeta(
+				ar.WebhookClientConfig{
+					Service: &ar.ServiceReference{
+						Namespace: "webhook",
+						Name:      "webhook-service",
+					},
+				},
+				nil,
+				2,
+			),
+			expected: nil,
+		},
+	}
+
+	webhookCheck := betaWebhookTimeoutCheck{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d, err := webhookCheck.Run(test.objs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, test.expected, d)
+		})
+	}
+}
+
+func webhookTimeoutTestObjectsBeta(
+	clientConfig ar.WebhookClientConfig,
+	timeoutSeconds *int32,
+	numNodes int,
+) *kube.Objects {
+	objs := &kube.Objects{
+		SystemNamespace: &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "kube-system",
+				Labels: map[string]string{"doks_test_key": "bar"},
+			},
+		},
+		Namespaces: &corev1.NamespaceList{
+			Items: []corev1.Namespace{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "kube-system",
+						Labels: map[string]string{"doks_test_key": "bar"},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "webhook",
+						Labels: map[string]string{"doks_test_key": "xyzzy"},
+					},
+				},
+			},
+		},
+		MutatingWebhookConfigurationsBeta: &ar.MutatingWebhookConfigurationList{
+			Items: []ar.MutatingWebhookConfiguration{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "MutatingWebhookConfiguration", APIVersion: "v1beta1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mwc_foo",
+					},
+					Webhooks: []ar.MutatingWebhook{
+						{
+							Name:           "mw_foo",
+							ClientConfig:   clientConfig,
+							TimeoutSeconds: timeoutSeconds,
+						},
+					},
+				},
+			},
+		},
+		ValidatingWebhookConfigurationsBeta: &ar.ValidatingWebhookConfigurationList{
+			Items: []ar.ValidatingWebhookConfiguration{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "ValidatingWebhookConfiguration", APIVersion: "v1beta1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vwc_foo",
+					},
+					Webhooks: []ar.ValidatingWebhook{
+						{
+							Name:           "vw_foo",
+							ClientConfig:   clientConfig,
+							TimeoutSeconds: timeoutSeconds,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	objs.Nodes = &corev1.NodeList{}
+	for i := 0; i < numNodes; i++ {
+		objs.Nodes.Items = append(objs.Nodes.Items, corev1.Node{})
+	}
+	return objs
+}
+
+func webhookTimeoutErrorsBeta() []checks.Diagnostic {
+	objs := webhookTimeoutTestObjectsBeta(ar.WebhookClientConfig{}, nil, 0)
+	validatingConfig := objs.ValidatingWebhookConfigurationsBeta.Items[0]
+	mutatingConfig := objs.MutatingWebhookConfigurationsBeta.Items[0]
+
+	diagnostics := []checks.Diagnostic{
+		{
+			Severity: checks.Error,
+			Message:  "Validating webhook with a TimeoutSeconds value greater than 29 seconds will block upgrades.",
+			Kind:     checks.ValidatingWebhookConfiguration,
+			Object:   &validatingConfig.ObjectMeta,
+			Owners:   validatingConfig.ObjectMeta.GetOwnerReferences(),
+		},
+		{
+			Severity: checks.Error,
+			Message:  "Mutating webhook with a TimeoutSeconds value greater than 29 seconds will block upgrades.",
+			Kind:     checks.MutatingWebhookConfiguration,
+			Object:   &mutatingConfig.ObjectMeta,
+			Owners:   mutatingConfig.ObjectMeta.GetOwnerReferences(),
+		},
+	}
+	return diagnostics
+}

--- a/kube/object_filter.go
+++ b/kube/object_filter.go
@@ -17,11 +17,10 @@ limitations under the License.
 package kube
 
 import (
-	// Load client-go authentication plugins
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 // ObjectFilter stores k8s object's fields that needs to be included or excluded while running checks

--- a/kube/objects.go
+++ b/kube/objects.go
@@ -25,6 +25,7 @@ import (
 	arv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	st "k8s.io/api/storage/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -192,7 +193,7 @@ func (c *Client) FetchObjects(ctx context.Context, filter ObjectFilter) (*Object
 		return nil, err
 	}
 
-	return objects, nil
+	return objectsWithoutNils(objects), nil
 }
 
 func annotateFetchError(kind string, err error) error {
@@ -206,6 +207,65 @@ func annotateFetchError(kind string, err error) error {
 	}
 
 	return fmt.Errorf("failed to fetch %s: %s", kind, err)
+}
+
+func objectsWithoutNils(objects *Objects) *Objects {
+	if objects.Nodes == nil {
+		objects.Nodes = &v1.NodeList{}
+	}
+	if objects.PersistentVolumes == nil {
+		objects.PersistentVolumes = &v1.PersistentVolumeList{}
+	}
+	if objects.Pods == nil {
+		objects.Pods = &v1.PodList{}
+	}
+	if objects.PodTemplates == nil {
+		objects.PodTemplates = &v1.PodTemplateList{}
+	}
+	if objects.PersistentVolumeClaims == nil {
+		objects.PersistentVolumeClaims = &v1.PersistentVolumeClaimList{}
+	}
+	if objects.ConfigMaps == nil {
+		objects.ConfigMaps = &v1.ConfigMapList{}
+	}
+	if objects.Services == nil {
+		objects.Services = &v1.ServiceList{}
+	}
+	if objects.Secrets == nil {
+		objects.Secrets = &v1.SecretList{}
+	}
+	if objects.ServiceAccounts == nil {
+		objects.ServiceAccounts = &v1.ServiceAccountList{}
+	}
+	if objects.ResourceQuotas == nil {
+		objects.ResourceQuotas = &v1.ResourceQuotaList{}
+	}
+	if objects.LimitRanges == nil {
+		objects.LimitRanges = &v1.LimitRangeList{}
+	}
+	if objects.StorageClasses == nil {
+		objects.StorageClasses = &st.StorageClassList{}
+	}
+	if objects.MutatingWebhookConfigurations == nil {
+		objects.MutatingWebhookConfigurations = &arv1.MutatingWebhookConfigurationList{}
+	}
+	if objects.ValidatingWebhookConfigurations == nil {
+		objects.ValidatingWebhookConfigurations = &arv1.ValidatingWebhookConfigurationList{}
+	}
+	if objects.MutatingWebhookConfigurationsBeta == nil {
+		objects.MutatingWebhookConfigurationsBeta = &arv1beta1.MutatingWebhookConfigurationList{}
+	}
+	if objects.ValidatingWebhookConfigurationsBeta == nil {
+		objects.ValidatingWebhookConfigurationsBeta = &arv1beta1.ValidatingWebhookConfigurationList{}
+	}
+	if objects.Namespaces == nil {
+		objects.Namespaces = &v1.NamespaceList{}
+	}
+	if objects.CronJobs == nil {
+		objects.CronJobs = &batchv1beta1.CronJobList{}
+	}
+
+	return objects
 }
 
 // NewClient builds a kubernetes client to interact with the live cluster.

--- a/kube/objects_test.go
+++ b/kube/objects_test.go
@@ -141,3 +141,37 @@ users:
 	}, metav1.CreateOptions{})
 	assert.Contains(t, err.Error(), "fail")
 }
+
+func TestAnnotateFetchError(t *testing.T) {
+	kindName := "kind"
+
+	tests := []struct {
+		name    string
+		inErr   error
+		wantErr error
+	}{
+		{
+			name:    "no error",
+			inErr:   nil,
+			wantErr: nil,
+		},
+		{
+			name: "not found error",
+			inErr: &kerrors.StatusError{
+				ErrStatus: metav1.Status{
+					Reason: metav1.StatusReasonNotFound,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "other error",
+			inErr:   errors.New("other error"),
+			wantErr: fmt.Errorf("failed to fetch %s: other error", kindName),
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.wantErr, annotateFetchError(kindName, test.inErr))
+	}
+}

--- a/kube/objects_test.go
+++ b/kube/objects_test.go
@@ -91,6 +91,7 @@ func TestFetchObjects(t *testing.T) {
 		assert.NotNil(t, actual.ValidatingWebhookConfigurations)
 		assert.NotNil(t, actual.MutatingWebhookConfigurations)
 		assert.NotNil(t, actual.SystemNamespace)
+		assert.NotNil(t, actual.CronJobs)
 	}
 
 }


### PR DESCRIPTION
We have a number of checks that operate on admission control webhook configuration. Older clusters support only v1beta1 of admission control, while newer clusters support v1. Currently clusterlint fails to run on these older clusters because we can't fetch v1 admission control objects from them.

This PR makes two changes to fix this:

1. When listing objects, ignore "not found" errors, which mean the cluster doesn't support the resource we're trying to list.
2. Duplicate our existing admission control webhook checks for v1beta1, so that older clusters get the same checks as newer clusters.

While we're here, enhance the errors we return when listing objects fails so that we can tell which resource we failed to list.
