### PR TITLE
Fix webhook test expectations

### DIFF
--- a/checks/doks/admission_controller_webhook_timeout_v1beta1_test.go
+++ b/checks/doks/admission_controller_webhook_timeout_v1beta1_test.go
@@ -133,7 +133,7 @@ func TestBetaWebhookTimeoutError(t *testing.T) {
 				toIntP(30),
 				2,
 			),
-			expected: webhookTimeoutErrors(),
+			expected: webhookTimeoutErrorsBeta(),
 		},
 		{
 			name: "TimeoutSeconds value is set to 31 seconds",
@@ -147,7 +147,7 @@ func TestBetaWebhookTimeoutError(t *testing.T) {
 				toIntP(31),
 				2,
 			),
-			expected: webhookTimeoutErrors(),
+			expected: webhookTimeoutErrorsBeta(),
 		},
 		{
 			name: "TimeoutSeconds value is set to nil",


### PR DESCRIPTION
The beta tests need to use the beta expectations as well.