### PR TITLE
Add the ability to run in-cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ If you're running clusterlint from within a Pod, you can use the `--in-cluster` 
 clusterlint --in-cluster run
 ```
 
+Here's a simple example of CronJob definition to run clusterlint in the default namespace without RBAC : 
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: clusterlint-cron
+spec:
+  schedule: "0 */1 * * *"
+  concurrencyPolicy: Replace
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: clusterlint
+              image: docker.io/clusterlint:latest
+              imagePullPolicy: IfNotPresent
+          restartPolicy: Never
+```
+
+If you're using RBAC, see [docs/RBAC.md](docs/RBAC.md).
+
 ### Specific checks and groups
 
 All checks that clusterlint performs are categorized into groups. A check can belong to multiple groups. This framework allows one to only run specific checks on a cluster. For instance, if a cluster is running on DOKS, then, running checks specific to AWS does not make sense. Clusterlint can blacklist aws related checks, if any while running against a DOKS cluster.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ clusterlint list [options]  // list all checks available
 clusterlint run [options]  // run all or specific checks
 ```
 
+### Running in-cluster
+
+If you're running clusterlint from within a Pod, you can use the `--in-cluster` flag to access the Kubernetes API from the Pod.
+
+```
+clusterlint --in-cluster run
+```
+
 ### Specific checks and groups
 
 All checks that clusterlint performs are categorized into groups. A check can belong to multiple groups. This framework allows one to only run specific checks on a cluster. For instance, if a cluster is running on DOKS, then, running checks specific to AWS does not make sense. Clusterlint can blacklist aws related checks, if any while running against a DOKS cluster.

--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -1,0 +1,68 @@
+The snippet below is an example to show how to run clusterlint in-cluster with RBAC enabled.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterlint-role
+rules:
+- apiGroups: [""]
+  resources:
+    - pods
+    - volumes
+    - deployments
+    - services
+    - cronjobs
+    - namespaces
+    - jobs
+    - persistentvolumeclaims
+    - persistentvolumes
+    - statefulsets
+    - storageclasses
+    - configmaps
+    - defaultstorageclass
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: clusterlint-role-binding
+  namespace: clusterlint
+subjects:
+  - kind: ServiceAccount
+    name: clusterlint
+    namespace: clusterlint
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: clusterlint-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clusterlint
+  namespace: clusterlint
+automountServiceAccountToken: false
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: clusterlint-cron
+  namespace: clusterlint
+spec:
+  schedule: "0 */1 * * *"
+  concurrencyPolicy: Replace
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: clusterlint
+          containers:
+            - name: clusterlint
+              image: docker.io/clusterlint:latest
+              imagePullPolicy: IfNotPresent
+          restartPolicy: Never
+```

--- a/kube/objects.go
+++ b/kube/objects.go
@@ -269,12 +269,8 @@ func objectsWithoutNils(objects *Objects) *Objects {
 }
 
 func NewClientConfigFromKubeConfig(opts *options) (*rest.Config, error) {
+	var err error
 	config := &rest.Config{}
-
-	err := opts.validate()
-	if err != nil {
-		return nil, err
-	}
 
 	if opts.yaml != nil {
 		config, err = clientcmd.RESTConfigFromKubeConfig(opts.yaml)
@@ -292,10 +288,6 @@ func NewClientConfigFromKubeConfig(opts *options) (*rest.Config, error) {
 
 	if err != nil {
 		return nil, err
-	}
-	config.Timeout = opts.timeout
-	if opts.transportWrapper != nil {
-		config.Wrap(opts.transportWrapper)
 	}
 
 	return config, nil
@@ -316,6 +308,11 @@ func NewClient(opts ...Option) (*Client, error) {
 	var config *rest.Config
 	var err error
 
+	err = defOpts.validate()
+	if err != nil {
+		return nil, err
+	}
+
 	if defOpts.inCluster {
 		config, err = rest.InClusterConfig()
 	} else {
@@ -323,6 +320,11 @@ func NewClient(opts ...Option) (*Client, error) {
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	config.Timeout = defOpts.timeout
+	if defOpts.transportWrapper != nil {
+		config.Wrap(defOpts.transportWrapper)
 	}
 
 	client, err := kubernetes.NewForConfig(config)

--- a/kube/objects.go
+++ b/kube/objects.go
@@ -268,6 +268,39 @@ func objectsWithoutNils(objects *Objects) *Objects {
 	return objects
 }
 
+func NewClientConfigFromKubeConfig(opts *options) (*rest.Config, error) {
+	config := &rest.Config{}
+
+	err := opts.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.yaml != nil {
+		config, err = clientcmd.RESTConfigFromKubeConfig(opts.yaml)
+	} else {
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		if len(opts.paths) != 0 {
+			loadingRules.Precedence = opts.paths
+		}
+		configOverrides := &clientcmd.ConfigOverrides{}
+		if opts.kubeContext != "" {
+			configOverrides.CurrentContext = opts.kubeContext
+		}
+		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	config.Timeout = opts.timeout
+	if opts.transportWrapper != nil {
+		config.Wrap(opts.transportWrapper)
+	}
+
+	return config, nil
+}
+
 // NewClient builds a kubernetes client to interact with the live cluster.
 // The kube config file path or the kubeconfig yaml must be specified
 // If not specified, defaults are assumed - configPath: ~/.kube/config, configContext: current context
@@ -282,31 +315,14 @@ func NewClient(opts ...Option) (*Client, error) {
 
 	var config *rest.Config
 	var err error
-	err = defOpts.validate()
-	if err != nil {
-		return nil, err
-	}
 
-	if defOpts.yaml != nil {
-		config, err = clientcmd.RESTConfigFromKubeConfig(defOpts.yaml)
+	if defOpts.inCluster {
+		config, err = rest.InClusterConfig()
 	} else {
-		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-		if len(defOpts.paths) != 0 {
-			loadingRules.Precedence = defOpts.paths
-		}
-		configOverrides := &clientcmd.ConfigOverrides{}
-		if defOpts.kubeContext != "" {
-			configOverrides.CurrentContext = defOpts.kubeContext
-		}
-		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
+		config, err = NewClientConfigFromKubeConfig(defOpts)
 	}
-
 	if err != nil {
 		return nil, err
-	}
-	config.Timeout = defOpts.timeout
-	if defOpts.transportWrapper != nil {
-		config.Wrap(defOpts.transportWrapper)
 	}
 
 	client, err := kubernetes.NewForConfig(config)

--- a/kube/objects_test.go
+++ b/kube/objects_test.go
@@ -107,6 +107,16 @@ func TestNewClientErrors(t *testing.T) {
 		assert.Equal(t, errors.New("cannot specify yaml and kubeconfig file paths"), err)
 	})
 
+	t.Run("both yaml and in-cluster specified", func(t *testing.T) {
+		_, err := NewClient(WithYaml([]byte("yaml")), InCluster())
+		assert.Equal(t, errors.New("cannot specify yaml or kubeconfig file paths when running in-cluster mode"), err)
+	})
+
+	t.Run("both KUBECONFIG and in-cluster specified", func(t *testing.T) {
+		_, err := NewClient(WithMergedConfigFiles([]string{"some-path"}), InCluster())
+		assert.Equal(t, errors.New("cannot specify yaml or kubeconfig file paths when running in-cluster mode"), err)
+	})
+
 	t.Run("in-cluster access enabled", func(t *testing.T) {
 		_, err := NewClient(InCluster())
 		assert.Equal(t, errors.New("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"), err)

--- a/kube/objects_test.go
+++ b/kube/objects_test.go
@@ -106,6 +106,11 @@ func TestNewClientErrors(t *testing.T) {
 		_, err := NewClient(WithMergedConfigFiles([]string{"some-path"}), WithYaml([]byte("yaml")))
 		assert.Equal(t, errors.New("cannot specify yaml and kubeconfig file paths"), err)
 	})
+
+	t.Run("in-cluster access enabled", func(t *testing.T) {
+		_, err := NewClient(InCluster())
+		assert.Equal(t, errors.New("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"), err)
+	})
 }
 
 type failTransport struct{}

--- a/kube/options.go
+++ b/kube/options.go
@@ -30,6 +30,7 @@ type options struct {
 	yaml             []byte
 	transportWrapper TransportWrapper
 	timeout          time.Duration
+	inCluster        bool
 }
 
 // Option function that allows injecting options while building kube.Client.
@@ -82,6 +83,14 @@ type TransportWrapper = func(http.RoundTripper) http.RoundTripper
 func WithTransportWrapper(f TransportWrapper) Option {
 	return func(o *options) error {
 		o.transportWrapper = f
+		return nil
+	}
+}
+
+// InCluster indicates that we are accessing the Kubernetes API from a Pod
+func InCluster() Option {
+	return func(o *options) error {
+		o.inCluster = true
 		return nil
 	}
 }

--- a/kube/options.go
+++ b/kube/options.go
@@ -99,5 +99,8 @@ func (o *options) validate() error {
 	if o.yaml != nil && len(o.paths) != 0 {
 		return errors.New("cannot specify yaml and kubeconfig file paths")
 	}
+	if (o.yaml != nil || len(o.paths) != 0) && o.inCluster {
+		return errors.New("cannot specify yaml or kubeconfig file paths when running in-cluster mode")
+	}
 	return nil
 }


### PR DESCRIPTION
Following https://github.com/digitalocean/clusterlint/issues/128

Until now, clusterlint was designed to be run locally using a kubeconfig file to access the Kubernetes API. But some users may want to run it in-cluster so it can be run as a CronJob for example.

**Note to reviewers**:

- I'm a new contributor and it's 12am here 😛  so feel free to tell me if I missed anything, especially for testing and documentation
- I was wondering if a `in-cluster` CLI flag was the good approach, or if we should just fallback to in-cluster when the kubeconfig path is empty ?
- Should I add an example manifest with ClusterRole for running clusterlint in-cluster ?
- I noticed this project does not have a Docker image, should I create it ?