### PR TITLE
Cluster linter checks in node's Overview tab

### DIFF
--- a/checks.md
+++ b/checks.md
@@ -1,4 +1,4 @@
-[Clusterlint](https://github.com/digitalocean/clusterlint) flags issues with workloads deployed in a cluster. These issues might cause workload downtime during maintenance or upgrade to a new Kubernetes version, and could complicate the maintenance or upgrade itself.
+[Clusterlint](https://github.com/digitalocean/clusterlint) flags issues with workloads deployed in a cluster. These issues might cause workload downtime during maintenance or upgrade to a new Kubernetes version, and could complicate the maintenance or upgrade itself. DigitalOcean runs a cluster linter check before a cluster upgrade. You can also run these checks yourself from the **Operational Readiness Check** section of a cluster's **Overview** node.
 
 ## Default Namespace
 


### PR DESCRIPTION
Addresses [PDOCS-1370](https://jira.internal.digitalocean.com/browse/PDOCS-1370). This [PDOCS section](https://docs.digitalocean.com/products/kubernetes/resources/clusterlint-errors/) is single-sourced with the `checks.md` content.