### PR TITLE
Return the correct node names in the node labels and taints check

### DIFF
--- a/checks/doks/node_labels_taints.go
+++ b/checks/doks/node_labels_taints.go
@@ -51,6 +51,7 @@ func (*nodeLabelsTaintsCheck) Description() string {
 func (c *nodeLabelsTaintsCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
 	var diagnostics []checks.Diagnostic
 	for _, node := range objects.Nodes.Items {
+		node := node
 		var customLabels, customTaints []string
 		for labelKey := range node.Labels {
 			if !isKubernetesLabel(labelKey) && !isDOKSLabel(labelKey) {

--- a/checks/doks/node_labels_taints_test.go
+++ b/checks/doks/node_labels_taints_test.go
@@ -79,6 +79,7 @@ func TestNodeLabels(t *testing.T) {
 				Kind:     checks.Node,
 				Details:  "Custom node labels: [example.com/another-label example.com/custom-label]",
 				Object: &metav1.ObjectMeta{
+					Name: "bad-node",
 					Labels: map[string]string{
 						"doks.digitalocean.com/foo":                "bar",
 						"doks.digitalocean.com/baz":                "xyzzy",
@@ -98,11 +99,24 @@ func TestNodeLabels(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			objects := &kube.Objects{
 				Nodes: &corev1.NodeList{
-					Items: []corev1.Node{{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: test.nodeLabels,
+					Items: []corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "good-node",
+							},
 						},
-					}},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:   "bad-node",
+								Labels: test.nodeLabels,
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "another-good-node",
+							},
+						},
+					},
 				},
 			}
 


### PR DESCRIPTION
Previously a loop variable was being used for the node name in the diagnostic returned from the node labels and taints check. If the offending node wasn't the last one in the list, the wrong node name would be returned.

Add a test to reproduce the issue, and copy the loop variable to fix it.

Thanks @kimschles for reporting this issue!