### PR TITLE
docs: fix anchor for resource-requirements

### DIFF
--- a/checks.md
+++ b/checks.md
@@ -664,7 +664,7 @@ This check reports all the secret names in the cluster that are not referenced b
 kubectl delete secret <unused secret name>
 ```
 
-## Resource Requests and Limits
+## Resource Requirements
 
 - Name: `resource-requirements`
 - Groups: `basic`


### PR DESCRIPTION
when a error for `resource-requirements` is found, DO links to https://docs.digitalocean.com/products/kubernetes/resources/clusterlint-errors/#resource-requirements, however that anchor is not found due to the heading of the section, this PR should fix the issue

![image](https://user-images.githubusercontent.com/5888506/158008796-73847a8f-ee4d-4572-bd7c-5030bede2d6d.png)

