### PR TITLE
fix: Clusterlint panic on valid PVCs when storageClassName specified as annotation

### DIFF
--- a/kube/objects.go
+++ b/kube/objects.go
@@ -110,7 +110,8 @@ func (c *Client) FetchObjects(ctx context.Context, filter ObjectFilter) (*Object
 		}
 		for _, s := range objects.StorageClasses.Items {
 			if v, _ := s.Annotations["storageclass.kubernetes.io/is-default-class"]; v == "true" {
-				objects.DefaultStorageClass = &s
+				defaultStorageClass := s
+				objects.DefaultStorageClass = &defaultStorageClass
 			}
 		}
 		return


### PR DESCRIPTION
fix assignment in loop, see https://github.com/golang/go/wiki/CommonMistakes#using-reference-to-loop-iterator-variable

Jira: CON-7086