### PR TITLE
fix: add app version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ COPY kube/ kube/
 COPY checks checks/
 
 # Build
+ARG version
 RUN GOFLAGS="-mod=vendor" CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
- go build -a -o clusterlint main.go
+    go build -ldflags="-X main.Version=$version" -a -o clusterlint main.go
 
 # Use distroless as minimal base image to package the clusterlint binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG ?= dev
 
 # Build the docker image
 docker-build:
-	docker build . -t ${IMG}:${TAG}
+	docker build . -t ${IMG}:${TAG} --build-arg version=${TAG}
 
 # Push the docker image
 docker-push:
@@ -12,12 +12,12 @@ docker-push:
 
 # Build all binaries and sha sums for release
 build-binaries:
-	GOOS=linux GOARCH=amd64 go build -mod=vendor -o clusterlint ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-linux-amd64.tar.gz ./clusterlint
-	GOOS=linux GOARCH=386 go build -mod=vendor -o clusterlint ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-linux-386.tar.gz ./clusterlint
-	GOOS=darwin GOARCH=amd64 go build -mod=vendor -o clusterlint ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-darwin-amd64.tar.gz ./clusterlint
-	GOOS=darwin GOARCH=arm64 go build -mod=vendor -o clusterlint ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-darwin-arm64.tar.gz ./clusterlint
-	GOOS=windows GOARCH=amd64 go build -mod=vendor -o clusterlint.exe ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-windows-amd64.tar.gz ./clusterlint
-	GOOS=windows GOARCH=386 go build -mod=vendor -o clusterlint.exe ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-windows-386.tar.gz ./clusterlint
+	GOOS=linux GOARCH=amd64 go build -mod=vendor -ldflags="-X main.Version=${TAG}" -o clusterlint ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-linux-amd64.tar.gz ./clusterlint
+	GOOS=linux GOARCH=386 go build -mod=vendor -ldflags="-X main.Version=${TAG}" -o clusterlint ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-linux-386.tar.gz ./clusterlint
+	GOOS=darwin GOARCH=amd64 go build -mod=vendor -ldflags="-X main.Version=${TAG}" -o clusterlint ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-darwin-amd64.tar.gz ./clusterlint
+	GOOS=darwin GOARCH=arm64 go build -mod=vendor -ldflags="-X main.Version=${TAG}" -o clusterlint ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-darwin-arm64.tar.gz ./clusterlint
+	GOOS=windows GOARCH=amd64 go build -mod=vendor -ldflags="-X main.Version=${TAG}" -o clusterlint.exe ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-windows-amd64.tar.gz ./clusterlint
+	GOOS=windows GOARCH=386 go build -mod=vendor -ldflags="-X main.Version=${TAG}" -o clusterlint.exe ./cmd/clusterlint; tar -czvf clusterlint-${TAG}-windows-386.tar.gz ./clusterlint
 	sha256sum clusterlint-${TAG}-linux-amd64.tar.gz >> clusterlint-${TAG}-checksums.sha256
 	sha256sum clusterlint-${TAG}-linux-386.tar.gz >> clusterlint-${TAG}-checksums.sha256
 	sha256sum clusterlint-${TAG}-darwin-amd64.tar.gz >> clusterlint-${TAG}-checksums.sha256

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ clusterlint --plugins=/path/to/plugin.so run -c my-plugin-check
 ## Release
 
 To release a new version of clusterlint, go to the actions page on GitHub, click on `Run workflow`.
-Specify the new tag to create. Make sure the tag is prefixed with `v`.
+Specify the new version tag to create. Make sure the tag is prefixed with `v` and `app.Version` in [cmd/clusterlint/main.go](cmd/clusterlint/main.go) is updated accordingly.
 
 The workflow does the following:
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ clusterlint --plugins=/path/to/plugin.so run -c my-plugin-check
 ## Release
 
 To release a new version of clusterlint, go to the actions page on GitHub, click on `Run workflow`.
-Specify the new version tag to create. Make sure the tag is prefixed with `v` and `app.Version` in [cmd/clusterlint/main.go](cmd/clusterlint/main.go) is updated accordingly.
+Specify the new tag to create. Make sure the tag is prefixed with `v`.
 
 The workflow does the following:
 

--- a/cmd/clusterlint/main.go
+++ b/cmd/clusterlint/main.go
@@ -36,11 +36,13 @@ import (
 
 const delimiter = ":"
 
+var Version string
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "clusterlint"
 	app.Usage = "Linter for k8s objects from a live cluster"
-	app.Version = "0.3.1"
+	app.Version = Version
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "kubeconfig",

--- a/cmd/clusterlint/main.go
+++ b/cmd/clusterlint/main.go
@@ -40,6 +40,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "clusterlint"
 	app.Usage = "Linter for k8s objects from a live cluster"
+	app.Version = "0.3.1"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "kubeconfig",


### PR DESCRIPTION
set the version which is returned by executing clusterlint --version

- added current version to app.Version, see [cli docs](https://pkg.go.dev/github.com/urfave/cli@v1.19.1#App)
- updated readme with a note to the release process

FIXES #145 