### PR TITLE
Add permissions in the in-cluster RBAC doc

### DIFF
--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -8,23 +8,49 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-    - pods
-    - volumes
-    - deployments
-    - services
-    - cronjobs
-    - namespaces
-    - jobs
-    - persistentvolumeclaims
-    - persistentvolumes
-    - statefulsets
-    - storageclasses
-    - configmaps
-    - defaultstorageclass
+   - configmaps
+   - cronjobs
+   - defaultstorageclass
+   - deployments
+   - jobs
+   - limitranges
+   - namespaces
+   - nodes
+   - persistentvolumeclaims
+   - persistentvolumes
+   - pods
+   - podtemplates
+   - resourcequotas
+   - secrets
+   - serviceaccounts
+   - services
+   - statefulsets
+   - storageclasses
+   - volumes
+   - volumesnapshots
   verbs: ["get", "watch", "list"]
+- apiGroups: ["snapshot.storage.k8s.io"]]
+  resources:
+  - volumesnapshotcontents
+  - volumesnapshots
+  verbs: ["get", "watch", "list"]
+ - apiGroups: ["batch"]
+   resources:
+   - cronjobs
+   verbs: ["get", "watch", "list"]
+ - apiGroups: ["admissionregistration.k8s.io"]
+   resources:
+   - validatingwebhookconfigurations
+   - mutatingwebhookconfigurations
+   verbs: ["get", "watch", "list"]
+ - apiGroups: ["storage.k8s.io"]
+   resources:
+   - storageclasses
+   - defaultstorageclass
+   verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: clusterlint-role-binding
   namespace: clusterlint

--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -10,7 +10,6 @@ rules:
   resources:
    - configmaps
    - cronjobs
-   - defaultstorageclass
    - deployments
    - jobs
    - limitranges
@@ -25,9 +24,7 @@ rules:
    - serviceaccounts
    - services
    - statefulsets
-   - storageclasses
    - volumes
-   - volumesnapshots
   verbs: ["get", "watch", "list"]
 - apiGroups: ["snapshot.storage.k8s.io"]]
   resources:
@@ -53,7 +50,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: clusterlint-role-binding
-  namespace: clusterlint
 subjects:
   - kind: ServiceAccount
     name: clusterlint

--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -26,7 +26,7 @@ rules:
    - statefulsets
    - volumes
   verbs: ["get", "watch", "list"]
-- apiGroups: ["snapshot.storage.k8s.io"]]
+- apiGroups: ["snapshot.storage.k8s.io"]
   resources:
   - volumesnapshotcontents
   - volumesnapshots


### PR DESCRIPTION
Clusterlint is rad, while trying to deploy it at work, I ran into API permission errors. Someone else might be trying to do this, so here's a docfix 😄 

This patch does three things:
- Add missing permissions for what seems like newer checks and API Groups
- Sorts the list of permissions
- Changes the RoleBinding to a ClusterRoleBinding so permissions can be picked up by the ServiceAccount