### PR TITLE
Allow multiple namespace flags

### DIFF
--- a/cmd/clusterlint/main.go
+++ b/cmd/clusterlint/main.go
@@ -103,12 +103,12 @@ func main() {
 					Name:  "C, ignore-checks",
 					Usage: "run a specific check",
 				},
-				cli.StringFlag{
-					Name:  "n, namespace",
+				cli.StringSliceFlag{
+					Name:  "n, namespaces",
 					Usage: "run checks in specific namespace",
 				},
-				cli.StringFlag{
-					Name:  "N, ignore-namespace",
+				cli.StringSliceFlag{
+					Name:  "N, ignore-namespaces",
 					Usage: "run checks not in specific namespace",
 				},
 				cli.StringFlag{
@@ -201,7 +201,7 @@ func runChecks(c *cli.Context) error {
 
 	diagnosticFilter := checks.DiagnosticFilter{Severity: checks.Severity(c.String("level"))}
 
-	objectFilter, err := kube.NewObjectFilter(c.String("n"), c.String("N"))
+	objectFilter, err := kube.NewObjectFilter(c.StringSlice("n"), c.StringSlice("N"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Since the `[ignore-]checks` flags can already be specified multiple times, now it can be done with the `[ignore-]namespaces` flags too. Their output is logically AND'ed.

The long options have been renamed from `namespace` to `namespaces` for consistency with the rest of the flags. This is a breaking change for those who use the long options but not the shorthands.

The precondition of specifying [either includes or excludes](https://github.com/digitalocean/clusterlint/blob/6b8757815e799609e10d83d9f6fe998b58f4c9cd/kube/object_filter.go#L34) is still valid.