### PR TITLE
dobs-pod-owner: address nil pointer deference

### DIFF
--- a/checks/doks/dobs_pod_owner.go
+++ b/checks/doks/dobs_pod_owner.go
@@ -92,6 +92,14 @@ func isDOBSVolume(volume corev1.Volume, namespace string, objects *kube.Objects)
 		}
 
 		scn := getStorageClassName(claim)
+
+		if scn == nil {
+			// ideally, this (scn == nil and defaultStorageClass == nil) shouldn't be possible because k8s will complain
+			// but it can happen if defaultStorageClass != nil at one point and user later changed the cluster to have no default sc
+			if objects.DefaultStorageClass == nil {
+				return false
+			}
+		}
 		if scn == nil && isDOCSI(objects.DefaultStorageClass.Provisioner) {
 			return true
 		}
@@ -109,7 +117,7 @@ func isDOBSVolume(volume corev1.Volume, namespace string, objects *kube.Objects)
 	return false
 }
 
-func getStorageClassName(claim *corev1.PersistentVolumeClaim) *string{
+func getStorageClassName(claim *corev1.PersistentVolumeClaim) *string {
 	if claim.Spec.StorageClassName != nil {
 		return claim.Spec.StorageClassName
 	}


### PR DESCRIPTION
Desc:

We were assuming a default storage class is always set, but DOKS users can change that in a cluster now. If old PVCs did not specify a storage class name and default storage class existed, that'd have been used to create the PV. However, old PVCs do not complain if default storage class gets unset later on. This caused the check to panic for such old PVCs. 