### PR TITLE
specify go-version in setup-go actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@0caeaed6fd66a828038c2da3c0f662a42862658f
         with:
-          go-version: go.mod
+          go-version: ^1.22
       - name: Check out code into the Go module directory
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Login to dockerhub to push the image


### PR DESCRIPTION
The release was failing for some reason: https://github.com/digitalocean/clusterlint/actions/runs/8994830775/job/24708887062#step:2:1

It doesn't specify what the error is but thought that switching `go-version` to a specific version might help 👍 