### PR TITLE
set required go.mod version back to 1.23.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digitalocean/clusterlint
 
-go 1.23.5
+go 1.23.1
 
 require (
 	github.com/docker/distribution v2.8.3+incompatible


### PR DESCRIPTION
Requiring 1.23.5 here translates into requiring 1.23.5 anywhere that imports clusterlint.
That's not nice cause not all repos can easily bump their version to 1.23.5