### PR TITLE
Added ValidatingAdmissionPolicy check to find policies which block cluster upgrades

### DIFF
--- a/checks.md
+++ b/checks.md
@@ -472,6 +472,84 @@ webhooks:
   timeoutSeconds: 10
 ```
 
+## Validating Admission Policy
+
+- Name: `validating-admission-policy`
+- Groups: `doks`
+
+[ValidatingAdmissionPolicies](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) evaluate CEL expressions in-process to accept or reject API requests. Like admission control webhooks, a policy that denies requests can disrupt upgrade and node replacement operations by preventing the DOKS reconciler from managing system components. This check flags a `ValidatingAdmissionPolicy` when all of the following are true:
+* It is referenced by a `ValidatingAdmissionPolicyBinding` whose `validationActions` include `Deny`. A policy with no binding, or one that only warns or audits, can never block a request.
+* Its `matchConstraints.resourceRules` apply to `v1`, `apps/v1`, `apps/v1beta1`, or `apps/v1beta2` resources.
+* It applies to the `kube-system` namespace once the policy and binding namespace selectors are combined.
+
+This check deliberately ignores `failurePolicy`. Unlike admission webhooks, a policy's `failurePolicy` only controls what happens when a CEL expression fails to evaluate. It does not affect validations that simply evaluate to `false`, so a policy enforced with `Deny` can block requests no matter how `failurePolicy` is set.
+
+For example, a cluster running the `safe-upgrades.gateway.networking.k8s.io` policy enforced through a `Deny` binding can get stuck in the `upgrading` or `reconcile pending` state because the reconciler's operations are rejected.
+
+### Example
+
+```yaml
+# Not recommended: a Deny-enforced policy that applies to core resources in kube-system.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: sample-policy.example.com
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["*"]
+      apiVersions: ["*"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["*"]
+  validations:
+  - expression: "false"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: sample-policy-binding.example.com
+spec:
+  policyName: sample-policy.example.com
+  validationActions: ["Deny"]
+```
+
+### How to Fix
+
+Use one of the following options:
+* Change the binding's `validationActions` to `Warn` or `Audit` instead of `Deny`.
+* Exclude the `kube-system` namespace with a `namespaceSelector` on the policy's `matchConstraints` or the binding's `matchResources`.
+* Scope the policy's `resourceRules` so they do not match the core or `apps` API groups that system components rely on during upgrades.
+
+```yaml
+# Recommended: exclude the kube-system namespace via a namespaceSelector.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: sample-policy.example.com
+spec:
+  matchConstraints:
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values: ["kube-system"]
+    resourceRules:
+    - apiGroups:   ["*"]
+      apiVersions: ["*"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["*"]
+  validations:
+  - expression: "false"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: sample-policy-binding.example.com
+spec:
+  policyName: sample-policy.example.com
+  validationActions: ["Deny"]
+```
+
 ## DOBS Pod Owner
 
 - Name: `dobs-pod-owner`

--- a/checks/diagnostic.go
+++ b/checks/diagnostic.go
@@ -76,6 +76,8 @@ const (
 	ValidatingWebhookConfiguration Kind = "validating webhook configuration"
 	// MutatingWebhookConfiguration identifies Kubernetes objects of kind `mutating webhook configuration`
 	MutatingWebhookConfiguration Kind = "mutating webhook configuration"
+	// ValidatingAdmissionPolicy identifies Kubernetes objects of kind `validating admission policy`
+	ValidatingAdmissionPolicy Kind = "validating admission policy"
 	// Node identifies a Kubernetes node object.
 	Node Kind = "node"
 	// VolumeSnapshot identifies a volume snapshot object

--- a/checks/doks/validating_admission_policy.go
+++ b/checks/doks/validating_admission_policy.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package doks
+
+import (
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+	ar "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func init() {
+	checks.Register(&validatingAdmissionPolicyCheck{})
+}
+
+type validatingAdmissionPolicyCheck struct{}
+
+func (c *validatingAdmissionPolicyCheck) Name() string {
+	return "validating-admission-policy"
+}
+
+func (c *validatingAdmissionPolicyCheck) Groups() []string {
+	return []string{"doks"}
+}
+
+func (c *validatingAdmissionPolicyCheck) Description() string {
+	return "Check for validating admission policies that could cause problems during upgrades or node replacement"
+}
+
+func (c *validatingAdmissionPolicyCheck) Run(objects *kube.Objects) ([]checks.Diagnostic, error) {
+	var diagnostics []checks.Diagnostic
+
+	for _, policy := range objects.ValidatingAdmissionPolicies.Items {
+		policy := policy
+
+		if policy.Spec.MatchConstraints == nil {
+			// A policy with no match constraints does not match anything.
+			continue
+		}
+		if !applicableNamedRules(policy.Spec.MatchConstraints.ResourceRules) {
+			// Policies that do not apply to core/v1, apps/v1, apps/v1beta1,
+			// apps/v1beta2 resources are fine.
+			continue
+		}
+		if !policyDeniesInNamespace(&policy, objects.ValidatingAdmissionPolicyBindings, objects.SystemNamespace) {
+			// To block reconciliation a policy needs a Deny-enforcing binding
+			// whose scope reaches kube-system, where the DOKS reconciler's upgrade
+			//  operations target system components.
+			continue
+		}
+
+		diagnostics = append(diagnostics, checks.Diagnostic{
+			Severity: checks.Error,
+			Message:  "Validating admission policy is configured in such a way that it may be problematic during upgrades.",
+			Kind:     checks.ValidatingAdmissionPolicy,
+			Object:   &policy.ObjectMeta,
+			Owners:   policy.ObjectMeta.GetOwnerReferences(),
+		})
+	}
+
+	return diagnostics, nil
+}
+
+// policyDeniesInNamespace reports whether the policy could deny requests in the
+// given namespace. A ValidatingAdmissionPolicy on its own never rejects
+// requests. Enforcement is configured by its bindings' validationActions.
+func policyDeniesInNamespace(policy *ar.ValidatingAdmissionPolicy, bindings *ar.ValidatingAdmissionPolicyBindingList, namespace *corev1.Namespace) bool {
+	if namespace == nil {
+		return false
+	}
+	if policy.Spec.MatchConstraints.NamespaceSelector != nil &&
+		!selectorMatchesNamespace(policy.Spec.MatchConstraints.NamespaceSelector, namespace) {
+		return false
+	}
+	for _, binding := range bindings.Items {
+		if binding.Spec.PolicyName != policy.Name {
+			continue
+		}
+		if !enforcesDeny(binding.Spec.ValidationActions) {
+			continue
+		}
+		if binding.Spec.MatchResources == nil ||
+			binding.Spec.MatchResources.NamespaceSelector == nil ||
+			selectorMatchesNamespace(binding.Spec.MatchResources.NamespaceSelector, namespace) {
+			return true
+		}
+	}
+	return false
+}
+
+// enforcesDeny reports whether the given validationActions include Deny.
+func enforcesDeny(actions []ar.ValidationAction) bool {
+	for _, action := range actions {
+		if action == ar.Deny {
+			return true
+		}
+	}
+	return false
+}
+
+// applicableNamedRules reports whether any of the policy's resource rules apply
+// to the core/v1, apps/v1, apps/v1beta1 or apps/v1beta2 API groups, mirroring
+// the logic used by the admission-controller-webhook-replacement check.
+func applicableNamedRules(rules []ar.NamedRuleWithOperations) bool {
+	plain := make([]ar.RuleWithOperations, 0, len(rules))
+	for _, r := range rules {
+		plain = append(plain, r.RuleWithOperations)
+	}
+	return applicable(plain)
+}

--- a/checks/doks/validating_admission_policy_test.go
+++ b/checks/doks/validating_admission_policy_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2026 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package doks
+
+import (
+	"testing"
+
+	"github.com/digitalocean/clusterlint/checks"
+	"github.com/digitalocean/clusterlint/kube"
+	"github.com/stretchr/testify/assert"
+	ar "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidatingAdmissionPolicyCheckMeta(t *testing.T) {
+	c := validatingAdmissionPolicyCheck{}
+	assert.Equal(t, "validating-admission-policy", c.Name())
+	assert.Equal(t, []string{"doks"}, c.Groups())
+	assert.NotEmpty(t, c.Description())
+}
+
+func TestValidatingAdmissionPolicyCheckRegistration(t *testing.T) {
+	c := &validatingAdmissionPolicyCheck{}
+	check, err := checks.Get("validating-admission-policy")
+	assert.NoError(t, err)
+	assert.Equal(t, check, c)
+}
+
+func TestValidatingAdmissionPolicyError(t *testing.T) {
+	fail := ar.Fail
+	ignore := ar.Ignore
+
+	tests := []struct {
+		name     string
+		objs     *kube.Objects
+		expected []checks.Diagnostic
+	}{
+		{
+			name: "no policies",
+			objs: &kube.Objects{
+				SystemNamespace:                   &corev1.Namespace{},
+				ValidatingAdmissionPolicies:       &ar.ValidatingAdmissionPolicyList{},
+				ValidatingAdmissionPolicyBindings: &ar.ValidatingAdmissionPolicyBindingList{},
+			},
+			expected: nil,
+		},
+		{
+			name: "policy with deny binding applies to core/v1 in kube-system",
+			objs: vapTestObjects(
+				&fail,
+				&metav1.LabelSelector{},
+				[]string{""},
+				[]string{"v1"},
+				[]ar.ValidationAction{ar.Deny},
+				nil,
+			),
+			expected: vapErrors(),
+		},
+		{
+			name: "policy applies to apps/v1",
+			objs: vapTestObjects(
+				&fail,
+				&metav1.LabelSelector{},
+				[]string{"apps"},
+				[]string{"v1"},
+				[]ar.ValidationAction{ar.Deny},
+				nil,
+			),
+			expected: vapErrors(),
+		},
+		{
+			name: "failurePolicy unset defaults to Fail",
+			objs: vapTestObjects(
+				nil,
+				&metav1.LabelSelector{},
+				[]string{"*"},
+				[]string{"*"},
+				[]ar.ValidationAction{ar.Deny},
+				nil,
+			),
+			expected: vapErrors(),
+		},
+		{
+			name: "failurePolicy is Ignore still flagged",
+			objs: vapTestObjects(
+				&ignore,
+				&metav1.LabelSelector{},
+				[]string{"*"},
+				[]string{"*"},
+				[]ar.ValidationAction{ar.Deny},
+				nil,
+			),
+			expected: vapErrors(),
+		},
+		{
+			name: "binding does not enforce deny",
+			objs: vapTestObjects(
+				&fail,
+				&metav1.LabelSelector{},
+				[]string{"*"},
+				[]string{"*"},
+				[]ar.ValidationAction{ar.Warn, ar.Audit},
+				nil,
+			),
+			expected: nil,
+		},
+		{
+			name: "policy has no binding",
+			objs: func() *kube.Objects {
+				objs := vapTestObjects(&fail, &metav1.LabelSelector{}, []string{"*"}, []string{"*"}, []ar.ValidationAction{ar.Deny}, nil)
+				objs.ValidatingAdmissionPolicyBindings = &ar.ValidatingAdmissionPolicyBindingList{}
+				return objs
+			}(),
+			expected: nil,
+		},
+		{
+			name: "policy does not apply to core/apps resources",
+			objs: vapTestObjects(
+				&fail,
+				&metav1.LabelSelector{},
+				[]string{"batch"},
+				[]string{"v1"},
+				[]ar.ValidationAction{ar.Deny},
+				nil,
+			),
+			expected: nil,
+		},
+		{
+			name: "policy namespace selector does not match kube-system",
+			objs: vapTestObjects(
+				&fail,
+				&metav1.LabelSelector{
+					MatchLabels: map[string]string{"non-existent-label": "bar"},
+				},
+				[]string{"*"},
+				[]string{"*"},
+				[]ar.ValidationAction{ar.Deny},
+				nil,
+			),
+			expected: nil,
+		},
+		{
+			name: "binding namespace selector excludes kube-system",
+			objs: vapTestObjects(
+				&fail,
+				&metav1.LabelSelector{},
+				[]string{"*"},
+				[]string{"*"},
+				[]ar.ValidationAction{ar.Deny},
+				&metav1.LabelSelector{
+					MatchLabels: map[string]string{"non-existent-label": "bar"},
+				},
+			),
+			expected: nil,
+		},
+	}
+
+	check := validatingAdmissionPolicyCheck{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d, err := check.Run(test.objs)
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, test.expected, d)
+		})
+	}
+}
+
+func vapTestObjects(
+	failurePolicy *ar.FailurePolicyType,
+	nsSelector *metav1.LabelSelector,
+	groups []string,
+	versions []string,
+	actions []ar.ValidationAction,
+	bindingNSSelector *metav1.LabelSelector,
+) *kube.Objects {
+	var matchResources *ar.MatchResources
+	if bindingNSSelector != nil {
+		matchResources = &ar.MatchResources{NamespaceSelector: bindingNSSelector}
+	}
+
+	return &kube.Objects{
+		SystemNamespace: &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "kube-system",
+				Labels: map[string]string{"doks_key": "bar"},
+			},
+		},
+		Namespaces: &corev1.NamespaceList{
+			Items: []corev1.Namespace{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "kube-system",
+						Labels: map[string]string{"doks_key": "bar"},
+					},
+				},
+			},
+		},
+		ValidatingAdmissionPolicies: &ar.ValidatingAdmissionPolicyList{
+			Items: []ar.ValidatingAdmissionPolicy{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "ValidatingAdmissionPolicy", APIVersion: "admissionregistration.k8s.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vap_foo",
+					},
+					Spec: ar.ValidatingAdmissionPolicySpec{
+						FailurePolicy: failurePolicy,
+						MatchConstraints: &ar.MatchResources{
+							NamespaceSelector: nsSelector,
+							ResourceRules: []ar.NamedRuleWithOperations{
+								{
+									RuleWithOperations: ar.RuleWithOperations{
+										Rule: ar.Rule{
+											APIGroups:   groups,
+											APIVersions: versions,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ValidatingAdmissionPolicyBindings: &ar.ValidatingAdmissionPolicyBindingList{
+			Items: []ar.ValidatingAdmissionPolicyBinding{
+				{
+					TypeMeta: metav1.TypeMeta{Kind: "ValidatingAdmissionPolicyBinding", APIVersion: "admissionregistration.k8s.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vap_foo_binding",
+					},
+					Spec: ar.ValidatingAdmissionPolicyBindingSpec{
+						PolicyName:        "vap_foo",
+						ValidationActions: actions,
+						MatchResources:    matchResources,
+					},
+				},
+			},
+		},
+	}
+}
+
+func vapErrors() []checks.Diagnostic {
+	objs := vapTestObjects(nil, &metav1.LabelSelector{}, []string{"*"}, []string{"*"}, []ar.ValidationAction{ar.Deny}, nil)
+	policy := objs.ValidatingAdmissionPolicies.Items[0]
+
+	return []checks.Diagnostic{
+		{
+			Severity: checks.Error,
+			Message:  "Validating admission policy is configured in such a way that it may be problematic during upgrades.",
+			Kind:     checks.ValidatingAdmissionPolicy,
+			Object:   &policy.ObjectMeta,
+			Owners:   policy.ObjectMeta.GetOwnerReferences(),
+		},
+	}
+}

--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -39,6 +39,8 @@ rules:
    resources:
    - validatingwebhookconfigurations
    - mutatingwebhookconfigurations
+   - validatingadmissionpolicies
+   - validatingadmissionpolicybindings
    verbs: ["get", "watch", "list"]
  - apiGroups: ["storage.k8s.io"]
    resources:

--- a/kube/objects.go
+++ b/kube/objects.go
@@ -41,7 +41,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
-//Identifier is used to identify a specific namspace scoped object.
+// Identifier is used to identify a specific namspace scoped object.
 type Identifier struct {
 	Name      string
 	Namespace string
@@ -49,28 +49,30 @@ type Identifier struct {
 
 // Objects encapsulates all the objects from a Kubernetes cluster.
 type Objects struct {
-	Nodes                           *corev1.NodeList
-	PersistentVolumes               *corev1.PersistentVolumeList
-	SystemNamespace                 *corev1.Namespace
-	Pods                            *corev1.PodList
-	PodTemplates                    *corev1.PodTemplateList
-	PersistentVolumeClaims          *corev1.PersistentVolumeClaimList
-	ConfigMaps                      *corev1.ConfigMapList
-	Services                        *corev1.ServiceList
-	Secrets                         *corev1.SecretList
-	ServiceAccounts                 *corev1.ServiceAccountList
-	ResourceQuotas                  *corev1.ResourceQuotaList
-	LimitRanges                     *corev1.LimitRangeList
-	VolumeSnapshotsV1               *csitypes.VolumeSnapshotList
-	VolumeSnapshotsV1Content        *csitypes.VolumeSnapshotContentList
-	VolumeSnapshotsBeta             *csitypesbeta.VolumeSnapshotList
-	VolumeSnapshotsBetaContent      *csitypesbeta.VolumeSnapshotContentList
-	StorageClasses                  *st.StorageClassList
-	DefaultStorageClass             *st.StorageClass
-	MutatingWebhookConfigurations   *arv1.MutatingWebhookConfigurationList
-	ValidatingWebhookConfigurations *arv1.ValidatingWebhookConfigurationList
-	Namespaces                      *corev1.NamespaceList
-	CronJobs                        *batchv1.CronJobList
+	Nodes                             *corev1.NodeList
+	PersistentVolumes                 *corev1.PersistentVolumeList
+	SystemNamespace                   *corev1.Namespace
+	Pods                              *corev1.PodList
+	PodTemplates                      *corev1.PodTemplateList
+	PersistentVolumeClaims            *corev1.PersistentVolumeClaimList
+	ConfigMaps                        *corev1.ConfigMapList
+	Services                          *corev1.ServiceList
+	Secrets                           *corev1.SecretList
+	ServiceAccounts                   *corev1.ServiceAccountList
+	ResourceQuotas                    *corev1.ResourceQuotaList
+	LimitRanges                       *corev1.LimitRangeList
+	VolumeSnapshotsV1                 *csitypes.VolumeSnapshotList
+	VolumeSnapshotsV1Content          *csitypes.VolumeSnapshotContentList
+	VolumeSnapshotsBeta               *csitypesbeta.VolumeSnapshotList
+	VolumeSnapshotsBetaContent        *csitypesbeta.VolumeSnapshotContentList
+	StorageClasses                    *st.StorageClassList
+	DefaultStorageClass               *st.StorageClass
+	MutatingWebhookConfigurations     *arv1.MutatingWebhookConfigurationList
+	ValidatingWebhookConfigurations   *arv1.ValidatingWebhookConfigurationList
+	ValidatingAdmissionPolicies       *arv1.ValidatingAdmissionPolicyList
+	ValidatingAdmissionPolicyBindings *arv1.ValidatingAdmissionPolicyBindingList
+	Namespaces                        *corev1.NamespaceList
+	CronJobs                          *batchv1.CronJobList
 }
 
 // Client encapsulates a client for a Kubernetes cluster.
@@ -184,6 +186,16 @@ func (c *Client) FetchObjects(ctx context.Context, filter ObjectFilter) (*Object
 		return
 	})
 	g.Go(func() (err error) {
+		objects.ValidatingAdmissionPolicies, err = admissionControllerClient.ValidatingAdmissionPolicies().List(gCtx, opts)
+		err = annotateFetchError("ValidatingAdmissionPolicies (v1)", err)
+		return
+	})
+	g.Go(func() (err error) {
+		objects.ValidatingAdmissionPolicyBindings, err = admissionControllerClient.ValidatingAdmissionPolicyBindings().List(gCtx, opts)
+		err = annotateFetchError("ValidatingAdmissionPolicyBindings (v1)", err)
+		return
+	})
+	g.Go(func() (err error) {
 		objects.Namespaces, err = client.Namespaces().List(gCtx, opts)
 		err = annotateFetchError("Namespaces", err)
 		return
@@ -276,6 +288,12 @@ func objectsWithoutNils(objects *Objects) *Objects {
 	}
 	if objects.ValidatingWebhookConfigurations == nil {
 		objects.ValidatingWebhookConfigurations = &arv1.ValidatingWebhookConfigurationList{}
+	}
+	if objects.ValidatingAdmissionPolicies == nil {
+		objects.ValidatingAdmissionPolicies = &arv1.ValidatingAdmissionPolicyList{}
+	}
+	if objects.ValidatingAdmissionPolicyBindings == nil {
+		objects.ValidatingAdmissionPolicyBindings = &arv1.ValidatingAdmissionPolicyBindingList{}
 	}
 	if objects.Namespaces == nil {
 		objects.Namespaces = &v1.NamespaceList{}

--- a/kube/objects_test.go
+++ b/kube/objects_test.go
@@ -54,6 +54,8 @@ func TestFetchObjects(t *testing.T) {
 				}
 				cs.PrependReactor("list", "mutatingwebhookconfigurations", notFoundReactionFunc)
 				cs.PrependReactor("list", "validatingwebhookconfigurations", notFoundReactionFunc)
+				cs.PrependReactor("list", "validatingadmissionpolicies", notFoundReactionFunc)
+				cs.PrependReactor("list", "validatingadmissionpolicybindings", notFoundReactionFunc)
 			},
 		},
 	}
@@ -93,6 +95,8 @@ func TestFetchObjects(t *testing.T) {
 		assert.NotNil(t, actual.LimitRanges)
 		assert.NotNil(t, actual.ValidatingWebhookConfigurations)
 		assert.NotNil(t, actual.MutatingWebhookConfigurations)
+		assert.NotNil(t, actual.ValidatingAdmissionPolicies)
+		assert.NotNil(t, actual.ValidatingAdmissionPolicyBindings)
 		assert.NotNil(t, actual.SystemNamespace)
 		assert.NotNil(t, actual.CronJobs)
 		assert.NotNil(t, actual.VolumeSnapshotsV1)


### PR DESCRIPTION
## Overview

DOKS clusters can get stuck mid-upgrade when a `ValidatingAdmissionPolicy` denies the operations our reconciler needs to roll the worker nodes. We hit this recently when a cluster sat in `reconcile pending` for ages with nothing useful in the reconciler logs, and it turned out a `safe-upgrades.gateway.networking.k8s.io` policy was quietly rejecting the reconciler's requests. Someone had to manually poke around the cluster's CRDs to figure that out.

clusterlint already catches the equivalent problem for admission webhooks, but it had no idea ValidatingAdmissionPolicies existed. This PR adds a new check so we catch this class of problem automatically instead of debugging it by hand.

The scoping is intentionally conservative \, matching the webhook check. The literal policy from the incident targets Gateway API resources cluster-wide, so it wouldn't be caught as-is. Happy to broaden this if we'd rather err toward more findings.

## Testing

Unit tests cover the meta/registration plus every filter branch. I also ran it against a real cluster to confirm the fetch wiring and RBAC, not just the logic:

1. `kind create cluster --image kindest/node:v1.30.0`
2. Applied a Deny-enforcing policy and  binding scoped to core resources in kube-system and then ran`clusterlint run -c validating-admission-policy` reported the error as expected.
3. Then flipped each condition one at a time and re-ran:
   - binding set to `Warn`  no finding
   - `failurePolicy: Ignore` no finding
   - binding deleted  no finding
   - policy excludes kube-system  no finding
   - policy scoped to `batch`/jobs  no finding

So only the risky shape gets flagged, and breaking any single condition silences it.

